### PR TITLE
Adds two new basis functions for creating AltAz masks.

### DIFF
--- a/python/lsst/sims/featureScheduler/basis_functions.py
+++ b/python/lsst/sims/featureScheduler/basis_functions.py
@@ -216,6 +216,162 @@ class North_south_patch_basis_function(Base_basis_function):
         return result
 
 
+class HADecAltAzPatchBasisFunction(Base_basis_function):
+    """Build an AltAz mask using patches defined as hour angle, declination, altitude and azimuth limits.
+
+    """
+    def __init__(self, nside=default_nside, condition_features=None, survey_features=None,
+                 patches=({'ha_min': 2., 'ha_max': 22.,
+                           'alt_max': 88., 'alt_min': 55.,
+                           'dec_min': -90., 'dec_max': 90,
+                           'az_min': 0., 'az_max': 360.},)):
+        """
+        Parameters
+        ----------
+        patches : list(dict())
+            A list of dictionaries containing the keywords (ha_min, ha_min), (alt_min, alt_max), (dec_min, dec_max),
+            (az_min and az_max) to construct an AltAz mask. One can skip a pair of min/max value if that is not
+            part of the patch definition. For instance patches = [{'alt_min': 30., 'alt_max': 86.5}] is a valid entry,
+            whereas patches = [{'alt_max': 86.5}] is not.
+        """
+        if nside is None:
+            nside = utils.set_default_nside()
+
+        self.nside = nside
+        if survey_features is None:
+            self.survey_features = {}
+        if condition_features is None:
+            self.condition_features = dict()
+            self.condition_features['altaz'] = features.AltAzFeature(nside=nside)
+            self.condition_features['lmst'] = features.Current_lmst()
+
+        self.patches = patches
+        ra, dec = utils.ra_dec_hp_map(self.nside)
+        self.ra_hours = ra*12./np.pi % 24.
+        self.dec_deg = dec*180./np.pi
+
+    def __call__(self, indx=None):
+        result = np.empty(hp.nside2npix(self.nside), dtype=float)
+        result.fill(hp.UNSEEN)
+
+        ha = (self.condition_features['lmst'].feature - self.ra_hours) % 24.
+
+        for patch in self.patches:
+            if 'ha_min' in patch and 'ha_max' in patch:
+                ha_mask = np.bitwise_or(ha <= patch['ha_min'],
+                                        ha >= patch['ha_max'])
+            else:
+                ha_mask = np.ones(hp.nside2npix(self.nside), dtype=bool)
+
+            if 'dec_min' in patch and 'dec_max' in patch:
+                dec_mask = np.bitwise_and(self.dec_deg >= patch['dec_min'],
+                                          self.dec_deg <= patch['dec_max'])
+            else:
+                dec_mask = np.ones(hp.nside2npix(self.nside), dtype=bool)
+
+            if 'alt_min' in patch and 'alt_max' in patch:
+                alt_mask = np.bitwise_and(self.condition_features['altaz'].feature['alt'] >=
+                                          patch['alt_min']*np.pi/180.,
+                                          self.condition_features['altaz'].feature['alt'] <=
+                                          patch['alt_max']*np.pi/180.)
+            else:
+                alt_mask = np.ones(hp.nside2npix(self.nside), dtype=bool)
+
+            if 'az_min' in patch and 'az_max' in patch:
+                az_mask = np.bitwise_and(self.condition_features['altaz'].feature['az'] >= patch['az_min']*np.pi/180.,
+                                         self.condition_features['altaz'].feature['az'] <= patch['az_max']*np.pi/180.)
+            else:
+                az_mask = np.ones(hp.nside2npix(self.nside), dtype=bool)
+
+            mask = np.bitwise_and(np.bitwise_and(np.bitwise_and(ha_mask,
+                                                                alt_mask),
+                                                 dec_mask),
+                                  az_mask)
+            result[mask] = 1.0
+
+        return result
+
+
+class MeridianStripeBasisFunction(Base_basis_function):
+    """Build an AltAz mask using a combination of meridian masks (width and height), zenith pad and a weights.
+
+    """
+    def __init__(self, nside=default_nside, condition_features=None, survey_features=None,
+                 width=(15.,), height=(80,), zenith_pad=(15.,), weight=(1.,), min_alt=20., max_alt=82.):
+        """
+        Parameters
+        ----------
+        width : list (15.,)
+            The width (East-West) of the meridian mask. (degrees)
+        height : list (80.,)
+            The height (North-South) of the meridian mask. (degrees)
+        zenith_pad : list (15., )
+            Radius of a circle around zenith. (degrees)
+        weight : list (1.,)
+            The weight for the specific region. Although any value is accepted, it should be something between [0-1.).
+        min_alt : float (20.)
+            Minimum allowed altitude. (degrees)
+        max_alt : float (82.)
+            Maximum allowed altitude. (degrees)
+        """
+        if nside is None:
+            nside = utils.set_default_nside()
+
+        len_width = len(width)
+        if not all([len_width == i for i in [len(height), len(zenith_pad), len(weight)]]):
+            raise ValueError('width[%i], height[%i], zenith_pad[%i] and weight[%i] must all have the same dimensions.'
+                             % (len_width, len(height), len(zenith_pad), len(weight)))
+
+        self.nside = nside
+        if survey_features is None:
+            self.survey_features = {}
+        if condition_features is None:
+            self.condition_features = dict()
+            self.condition_features['altaz'] = features.AltAzFeature(nside=nside)
+            self.condition_features['lmst'] = features.Current_lmst()
+
+        self.width = [w*np.pi/180. for w in width]  # converts to radians
+        self.height = [h*np.pi/180. for h in height] # converts to radians
+        self.zenith_pad_rad = [z*np.pi/180. for z in zenith_pad] # converts to radians
+        self.weight = weight
+
+        self.max_alt_rad = max_alt*np.pi/180.
+        self.min_alt_rad = min_alt*np.pi/180.
+
+        ra, dec = utils.ra_dec_hp_map(self.nside)
+        self.ra_hours = ra*12./np.pi % 24.
+        self.dec_deg = dec*180./np.pi
+
+    def __call__(self, indx=None):
+        result = np.empty(hp.nside2npix(self.nside), dtype=float)
+        result.fill(hp.UNSEEN)
+
+        alt = self.condition_features['altaz'].feature['alt']
+        az = self.condition_features['altaz'].feature['az']
+
+        z_dist = np.pi/2.-alt  # Zenith distance
+
+        sin_az = np.abs(np.sin(az))
+        cos_az = np.abs(np.cos(az))
+
+        width = sin_az * z_dist
+        height = cos_az * z_dist
+
+        # Put meridian stripes. Sort by weight so larger weight goes last
+        for i in np.argsort(self.weight):
+            result[np.bitwise_and(width < self.width[i],
+                                  height < self.height[i])] = self.weight[i]
+
+            # Put zenith pad
+            if self.zenith_pad_rad[i] > 0.:
+                result[np.where(z_dist < self.zenith_pad_rad[i])] = self.weight[i]
+
+        # Now excludes minimum and maximum altitudes
+        result[np.where(alt < self.min_alt_rad)] = hp.UNSEEN
+        result[np.where(alt > self.max_alt_rad)] = hp.UNSEEN
+
+        return result
+
 class Target_map_basis_function(Base_basis_function):
     """Normalize the maps first to make things smoother
     """

--- a/tests/test_BasisFuncs.py
+++ b/tests/test_BasisFuncs.py
@@ -36,6 +36,62 @@ class TestBasis(unittest.TestCase):
         bf.update_conditions(conditions)
         self.assertEqual(np.max(bf()), 0.)
 
+    def testHADecAltAzPatchBasisFunction(self):
+        """Basic test for the HADecAltAzPatchBasisFunction. Just make sure the default parameter returns a mask
+        with observable regions.
+        """
+
+        bf = fs.HADecAltAzPatchBasisFunction()
+
+        mjd = 59000.
+        altaz_feature = fs.AltAzFeature()
+
+        site = fs.Site(name='LSST')
+        lmst, last = fs.calcLmstLast(mjd, site.longitude_rad)
+        lmst_feature = fs.Current_lmst()
+        conditions = {'altaz': altaz_feature,
+                      'lmst': lmst,
+                      'mjd': mjd}
+
+        lmst_feature.update_conditions(conditions)
+        altaz_feature.update_conditions(conditions=conditions)
+
+        bf.update_conditions(conditions)
+
+        mask = bf()
+
+        # Just check that the default mask has valid values. In the future could add a mask here and make sure they
+        # are the same.
+        self.assertTrue(np.any(mask == 1.))
+
+    def testMeridianStripeBasisFunction(self):
+        """Basic test for the MeridianStripeBasisFunction. Just make sure the default parameter returns a mask
+        with observable regions.
+        """
+
+        bf = fs.MeridianStripeBasisFunction()
+
+        mjd = 59000.
+        altaz_feature = fs.AltAzFeature()
+
+        site = fs.Site(name='LSST')
+        lmst, last = fs.calcLmstLast(mjd, site.longitude_rad)
+        lmst_feature = fs.Current_lmst()
+        conditions = {'altaz': altaz_feature,
+                      'lmst': lmst,
+                      'mjd': mjd}
+
+        lmst_feature.update_conditions(conditions)
+        altaz_feature.update_conditions(conditions=conditions)
+
+        bf.update_conditions(conditions)
+
+        mask = bf()
+
+        # Just check that the default mask has valid values. In the future could add a mask here and make sure they
+        # are the same.
+        self.assertTrue(np.any(mask == 1.))
+
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass


### PR DESCRIPTION
	- HADecAltAzPatchBasisFunction: Create masks using a combination of patches defined as hour angle, declination, altitude and azimuth limits.
	- MeridianStripeBasisFunction: Create masks using a combination of meridian mask and zenith pad. Also allows different weights to be applied to different regions.