### PR TITLE
This commit implements the latest changes on effort to produce baseline simulations with the feature based scheduler.

### DIFF
--- a/examples/complex_fbs_with_socs.ipynb
+++ b/examples/complex_fbs_with_socs.ipynb
@@ -1,0 +1,476 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Feature Based Scheduler run with SOCS and custom scheduler configuration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This example notebook show how to do a slightly more complex 1 day FBS run using SOCS. In this example we use a custom FBS configuration done directly on the notebook.\n",
+    "\n",
+    "Before running the notebook make sure you run `manage_db --save-dir $HOME/run_local/output/` on the command line to setup the SOCS database. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import healpy as hp\n",
+    "import numpy as np\n",
+    "\n",
+    "import lsst.sims.featureScheduler as fs\n",
+    "\n",
+    "from lsst.sims.featureScheduler.driver import FeatureSchedulerDriver as Driver\n",
+    "\n",
+    "from lsst.sims.ocs.database import SocsDatabase\n",
+    "from lsst.sims.ocs.kernel import Simulator\n",
+    "from lsst.sims.ocs.setup import create_parser\n",
+    "from lsst.sims.ocs.setup import apply_file_config, read_file_config\n",
+    "\n",
+    "from lsst.ts.scheduler.kernel import SurveyTopology"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logging.getLogger().setLevel(logging.INFO)\n",
+    "logging.basicConfig(level=logging.INFO,\n",
+    "                    format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',\n",
+    "                    datefmt='%m-%d %H:%M')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This next cell loads default command line arguments. These are needed mainly to setup the simulation database."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parser = create_parser()\n",
+    "args = parser.parse_known_args()[0]\n",
+    "prog_conf = read_file_config()\n",
+    "if prog_conf is not None:\n",
+    "    apply_file_config(prog_conf, args)\n",
+    "print(args.sqlite_save_dir, args.session_id_start, args.sqlite_session_save_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Setup socs database to store simulations results, if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "db = SocsDatabase(sqlite_save_path=args.sqlite_save_dir,\n",
+    "                  session_id_start=args.session_id_start,\n",
+    "                  sqlite_session_save_path=args.sqlite_session_save_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "session_id = db.new_session(\"FBS test on notebook\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now define a driver for the simulation. In this case, we already imported the FBS driver as Driver so we simply call it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "driver = Driver()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default the duration of a simulation is 10 years. Here we will run a single day."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "args.frac_duration = 0.003"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now set the SOCS simulator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim = Simulator(args, db, driver=driver)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Up to this point, the scheduler is still not configured. Let's make a custom configuration. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "survey_topology = SurveyTopology()\n",
+    "survey_topology.num_general_props = 4\n",
+    "survey_topology.general_propos = [\"NorthEclipticSpur\", \"SouthCelestialPole\", \"WideFastDeep\", \"GalacticPlane\"]\n",
+    "survey_topology.num_seq_props = 1\n",
+    "survey_topology.sequence_propos = [\"DeepDrillingCosmology1\"]\n",
+    "\n",
+    "target_maps = {}\n",
+    "nside = fs.set_default_nside(nside=32)  # Required\n",
+    "\n",
+    "target_maps['u'] = fs.generate_goal_map(NES_fraction=0.,\n",
+    "                                        WFD_fraction=0.31, SCP_fraction=0.08,\n",
+    "                                        GP_fraction=0.004,\n",
+    "                                        WFD_upper_edge_fraction=0.0,\n",
+    "                                        nside=nside,\n",
+    "                                        generate_id_map=True)\n",
+    "target_maps['g'] = fs.generate_goal_map(NES_fraction=0.2,\n",
+    "                                        WFD_fraction=0.44, SCP_fraction=0.08,\n",
+    "                                        GP_fraction=0.004,\n",
+    "                                        WFD_upper_edge_fraction=0.0,\n",
+    "                                        nside=nside,\n",
+    "                                        generate_id_map=True)\n",
+    "target_maps['r'] = fs.generate_goal_map(NES_fraction=0.46,\n",
+    "                                        WFD_fraction=1.0, SCP_fraction=0.08,\n",
+    "                                        WFD_upper_edge_fraction=0.0,\n",
+    "                                        GP_fraction=0.004,\n",
+    "                                        nside=nside,\n",
+    "                                        generate_id_map=True)\n",
+    "target_maps['i'] = fs.generate_goal_map(NES_fraction=0.46,\n",
+    "                                        WFD_fraction=1.0, SCP_fraction=0.08,\n",
+    "                                        GP_fraction=0.004,\n",
+    "                                        WFD_upper_edge_fraction=0.0,\n",
+    "                                        nside=nside,\n",
+    "                                        generate_id_map=True)\n",
+    "target_maps['z'] = fs.generate_goal_map(NES_fraction=0.4,\n",
+    "                                        WFD_fraction=0.9, SCP_fraction=0.08,\n",
+    "                                        GP_fraction=0.004,\n",
+    "                                        WFD_upper_edge_fraction=0.0,\n",
+    "                                        nside=nside,\n",
+    "                                        generate_id_map=True)\n",
+    "target_maps['y'] = fs.generate_goal_map(NES_fraction=0.,\n",
+    "                                        WFD_fraction=0.9, SCP_fraction=0.08,\n",
+    "                                        GP_fraction=0.004,\n",
+    "                                        WFD_upper_edge_fraction=0.0,\n",
+    "                                        nside=nside,\n",
+    "                                        generate_id_map=True)\n",
+    "\n",
+    "cloud_map = fs.utils.generate_cloud_map(target_maps, filtername='r',\n",
+    "                                        wfd_cloud_max=0.7,\n",
+    "                                        scp_cloud_max=0.7,\n",
+    "                                        gp_cloud_max=0.7,\n",
+    "                                        nes_cloud_max=0.7)\n",
+    "\n",
+    "# x1 = 30.\n",
+    "# x0 = 2.\n",
+    "# B = x1 / (x1 - x0)\n",
+    "# A = -B / x1\n",
+    "# width = np.arange(x0, x1, 0.5)\n",
+    "# z_pad = width + 8.\n",
+    "# weight = (A * width + B)\n",
+    "# height = np.zeros_like(width) + 80.\n",
+    "\n",
+    "width = (10.,)\n",
+    "z_pad = (18.,)\n",
+    "weight = (1.,)\n",
+    "height = (80.,)\n",
+    "\n",
+    "filters = ['u', 'g', 'r', 'i', 'z', 'y']\n",
+    "surveys = []\n",
+    "\n",
+    "sb_limit_map = fs.utils.generate_sb_map(target_maps, filters)\n",
+    "\n",
+    "filter_prop = {'u': 0.069,\n",
+    "               'g': 0.097,\n",
+    "               'r': 0.222,\n",
+    "               'i': 0.222,\n",
+    "               'z': 0.194,\n",
+    "               'y': 0.194}\n",
+    "\n",
+    "for filtername in filters:\n",
+    "    bfs = list()\n",
+    "    # bfs.append(fs.M5_diff_basis_function(filtername=filtername, nside=nside))\n",
+    "    bfs.append(fs.HourAngle_bonus_basis_function(max_hourangle=3.))\n",
+    "    bfs.append(fs.Skybrightness_limit_basis_function(nside=nside,\n",
+    "                                                     filtername=filtername,\n",
+    "                                                     min=sb_limit_map[filtername]['min'],\n",
+    "                                                     max=sb_limit_map[filtername]['max']))\n",
+    "    bfs.append(fs.Target_map_basis_function(filtername=filtername,\n",
+    "                                            target_map=target_maps[filtername][0],\n",
+    "                                            out_of_bounds_val=hp.UNSEEN, nside=nside))\n",
+    "    bfs.append(fs.MeridianStripeBasisFunction(nside=nside,width=width,\n",
+    "                                              weight=weight,\n",
+    "                                              height=height,\n",
+    "                                              zenith_pad=z_pad))\n",
+    "    # bfs.append(fs.HADecAltAzPatchBasisFunction(nside=nside,\n",
+    "    #                                            patches=patches[::-1]))\n",
+    "    bfs.append(fs.Agreesive_Slewtime_basis_function(filtername=filtername, nside=nside, order=6., hard_max=20.))\n",
+    "    bfs.append(fs.Goal_Strict_filter_basis_function(filtername=filtername,\n",
+    "                                               time_lag_min=90.,\n",
+    "                                               time_lag_max=150.,\n",
+    "                                               time_lag_boost=180.,\n",
+    "                                               boost_gain=1.0,\n",
+    "                                               unseen_before_lag=True,\n",
+    "                                               proportion=filter_prop[filtername],\n",
+    "                                               aways_available=filtername in 'zy'))\n",
+    "    bfs.append(fs.Avoid_Fast_Revists(filtername=None, gap_min=240., nside=nside))\n",
+    "    bfs.append(fs.Bulk_cloud_basis_function(max_cloud_map=cloud_map, nside=nside))\n",
+    "    bfs.append(fs.Moon_avoidance_basis_function(nside=nside, moon_distance=40.))\n",
+    "    # bfs.append(fs.CableWrap_unwrap_basis_function(nside=nside, activate_tol=70., unwrap_until=315,\n",
+    "    #                                               max_duration=90.))\n",
+    "    # bfs.append(fs.NorthSouth_scan_basis_function(length=70.))\n",
+    "\n",
+    "    weights = np.array([2., 0.1, .1, 1., 3., 1.5, 1.0, 1.0, 1.0])\n",
+    "    surveys.append(fs.Greedy_survey_fields(bfs, weights, block_size=1,\n",
+    "                                           filtername=filtername, dither=True,\n",
+    "                                           nside=nside,\n",
+    "                                           tag_fields=True,\n",
+    "                                           tag_map=target_maps[filtername][1],\n",
+    "                                           tag_names=target_maps[filtername][2],\n",
+    "                                           ignore_obs='DD'))\n",
+    "\n",
+    "# Set up pairs\n",
+    "pairs_bfs = []\n",
+    "\n",
+    "pair_map = np.zeros(len(target_maps['z'][0]))\n",
+    "pair_map.fill(hp.UNSEEN)\n",
+    "wfd = np.where(target_maps['z'][1] == 3)\n",
+    "nes = np.where(target_maps['z'][1] == 1)\n",
+    "pair_map[wfd] = 1.\n",
+    "pair_map[nes] = 1.\n",
+    "\n",
+    "pairs_bfs.append(fs.Target_map_basis_function(filtername='',\n",
+    "                                              target_map=pair_map,\n",
+    "                                              out_of_bounds_val=hp.UNSEEN, nside=nside))\n",
+    "pairs_bfs.append(fs.MeridianStripeBasisFunction(nside=nside, zenith_pad=(45.,), width=(35.,)))\n",
+    "pairs_bfs.append(fs.Moon_avoidance_basis_function(nside=nside, moon_distance=30.))\n",
+    "\n",
+    "# surveys.append(fs.Pairs_survey_scripted(pairs_bfs, [1., 1., 1.], ignore_obs='DD', min_alt=20.))\n",
+    "surveys.append(fs.Pairs_different_filters_scripted(pairs_bfs, [1., 1., 1.], ignore_obs='DD', min_alt=20.,\n",
+    "                                                   filter_goals=filter_prop))\n",
+    "# surveys.append(fs.Pairs_survey_scripted([], [], ignore_obs='DD'))\n",
+    "\n",
+    "# Set up the DD\n",
+    "# ELAIS S1\n",
+    "surveys.append(fs.Deep_drilling_survey(9.45, -44., sequence='rgizy',\n",
+    "                                       nvis=[20, 10, 20, 26, 20],\n",
+    "                                       survey_name='DD:ELAISS1', reward_value=100, moon_up=None,\n",
+    "                                       fraction_limit=0.148, ha_limits=([0., 0.5], [23.5, 24.]),\n",
+    "                                       nside=nside,\n",
+    "                                       avoid_same_day=True,\n",
+    "                                       filter_goals=filter_prop))\n",
+    "surveys.append(fs.Deep_drilling_survey(9.45, -44., sequence='u',\n",
+    "                                       nvis=[7],\n",
+    "                                       survey_name='DD:u,ELAISS1', reward_value=100, moon_up=False,\n",
+    "                                       fraction_limit=0.0012, ha_limits=([0., 0.5], [23.5, 24.]),\n",
+    "                                       nside=nside))\n",
+    "\n",
+    "# XMM-LSS\n",
+    "surveys.append(fs.Deep_drilling_survey(35.708333, -4 - 45 / 60., sequence='rgizy',\n",
+    "                                       nvis=[20, 10, 20, 26, 20],\n",
+    "                                       survey_name='DD:XMM-LSS', reward_value=100, moon_up=None,\n",
+    "                                       fraction_limit=0.148, ha_limits=([0., 0.5], [23.5, 24.]),\n",
+    "                                       nside=nside,\n",
+    "                                       avoid_same_day=True,\n",
+    "                                       filter_goals=filter_prop))\n",
+    "surveys.append(fs.Deep_drilling_survey(35.708333, -4 - 45 / 60., sequence='u',\n",
+    "                                       nvis=[7],\n",
+    "                                       survey_name='DD:u,XMM-LSS', reward_value=100, moon_up=False,\n",
+    "                                       fraction_limit=0.0012, ha_limits=([0., 0.5], [23.5, 24.]),\n",
+    "                                       nside=nside))\n",
+    "\n",
+    "# Extended Chandra Deep Field South\n",
+    "# XXX--Note, this one can pass near zenith. Should go back and add better planning on this.\n",
+    "surveys.append(fs.Deep_drilling_survey(53.125, -28. - 6 / 60., sequence='rgizy',\n",
+    "                                       nvis=[20, 10, 20, 26, 20],\n",
+    "                                       survey_name='DD:ECDFS', reward_value=100, moon_up=None,\n",
+    "                                       fraction_limit=0.148, ha_limits=[[0.5, 1.0], [23., 22.5]],\n",
+    "                                       nside=nside,\n",
+    "                                       avoid_same_day=True,\n",
+    "                                       filter_goals=filter_prop))\n",
+    "surveys.append(fs.Deep_drilling_survey(53.125, -28. - 6 / 60., sequence='u',\n",
+    "                                       nvis=[7],\n",
+    "                                       survey_name='DD:u,ECDFS', reward_value=100, moon_up=False,\n",
+    "                                       fraction_limit=0.0012, ha_limits=[[0.5, 1.0], [23., 22.5]],\n",
+    "                                       nside=nside))\n",
+    "# COSMOS\n",
+    "surveys.append(fs.Deep_drilling_survey(150.1, 2. + 10. / 60. + 55 / 3600., sequence='rgizy',\n",
+    "                                       nvis=[20, 10, 20, 26, 20],\n",
+    "                                       survey_name='DD:COSMOS', reward_value=100, moon_up=None,\n",
+    "                                       fraction_limit=0.148, ha_limits=([0., 0.5], [23.5, 24.]),\n",
+    "                                       nside=nside,\n",
+    "                                       avoid_same_day=True,\n",
+    "                                       filter_goals=filter_prop))\n",
+    "surveys.append(fs.Deep_drilling_survey(150.1, 2. + 10. / 60. + 55 / 3600., sequence='u',\n",
+    "                                       nvis=[7], ha_limits=([0., .5], [23.5, 24.]),\n",
+    "                                       survey_name='DD:u,COSMOS', reward_value=100, moon_up=False,\n",
+    "                                       fraction_limit=0.0012,\n",
+    "                                       nside=nside))\n",
+    "\n",
+    "# Extra DD Field, just to get to 5. Still not closed on this one\n",
+    "surveys.append(fs.Deep_drilling_survey(349.386443, -63.321004, sequence='rgizy',\n",
+    "                                       nvis=[20, 10, 20, 26, 20],\n",
+    "                                       survey_name='DD:290', reward_value=100, moon_up=None,\n",
+    "                                       fraction_limit=0.148, ha_limits=([0., 0.5], [23.5, 24.]),\n",
+    "                                       nside=nside,\n",
+    "                                       avoid_same_day=True,\n",
+    "                                       filter_goals=filter_prop))\n",
+    "surveys.append(fs.Deep_drilling_survey(349.386443, -63.321004, sequence='u',\n",
+    "                                       nvis=[7],\n",
+    "                                       survey_name='DD:u,290', reward_value=100, moon_up=False,\n",
+    "                                       fraction_limit=0.0012, ha_limits=([0., 0.5], [23.5, 24.]),\n",
+    "                                       nside=nside,\n",
+    "                                       filter_goals=filter_prop))\n",
+    "\n",
+    "scheduler = fs.Core_scheduler(surveys, nside=nside)  # Required"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we load the configuration to driver. We basically need to two two steps, load `scheduler`, `nside` and `survey_topology`.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim.driver.scheduler = scheduler\n",
+    "sim.driver.sky_nside = nside\n",
+    "\n",
+    "sim.conf_comm.num_proposals = survey_topology.num_props\n",
+    "sim.conf_comm.survey_topology['general'] = survey_topology.general_propos\n",
+    "sim.conf_comm.survey_topology['sequence'] = survey_topology.sequence_propos"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now initialize the simulator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim.initialize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And we are ready to run the simulation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now have access to all the scheduler data structure to play with. In the cell bellow, we plot the TargetMapBasis function for the `r` filter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hp.mollview(sim.driver.scheduler.survey_lists[0][2].basis_functions[2]())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/simple_fbs_with_socs.ipynb
+++ b/examples/simple_fbs_with_socs.ipynb
@@ -1,0 +1,215 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Simple Feature Based Scheduler run with SOCS"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This example notebook show how to do a simple 1 day FBS run using SOCS. In this example we use the default FBS configuration, a separate example will be given on how to provide a custom configuration. \n",
+    "\n",
+    "Before running the notebook make sure you run `manage_db --save-dir $HOME/run_local/output/` on the command line to setup the SOCS database. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import healpy as hp\n",
+    "\n",
+    "from lsst.sims.ocs.database import SocsDatabase\n",
+    "from lsst.sims.ocs.kernel import Simulator\n",
+    "from lsst.sims.featureScheduler.driver import FeatureSchedulerDriver as Driver\n",
+    "from lsst.sims.ocs.setup import create_parser\n",
+    "from lsst.sims.ocs.setup import apply_file_config, read_file_config"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logging.getLogger().setLevel(logging.INFO)\n",
+    "logging.basicConfig(level=logging.INFO,\n",
+    "                    format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',\n",
+    "                    datefmt='%m-%d %H:%M')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This next cell loads default command line arguments. These are needed mainly to setup the database."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parser = create_parser()\n",
+    "args = parser.parse_known_args()[0]\n",
+    "prog_conf = read_file_config()\n",
+    "if prog_conf is not None:\n",
+    "    apply_file_config(prog_conf, args)\n",
+    "print(args.sqlite_save_dir, args.session_id_start, args.sqlite_session_save_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Setup socs database to store simulations results, if needed. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "db = SocsDatabase(sqlite_save_path=args.sqlite_save_dir,\n",
+    "                  session_id_start=args.session_id_start,\n",
+    "                  sqlite_session_save_path=args.sqlite_session_save_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "session_id = db.new_session(\"FBS test on notebook\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now define a driver for the simulation. In this case, we already imported the FBS driver as Driver so we simply call it. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "driver = Driver()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default the duration of a simulation is 10 years. Here we will run a single day. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "args.frac_duration = 0.003"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now set the SOCS simulator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim = Simulator(args, db, driver=driver)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim.initialize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And run the simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "sim.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now have access to all the scheduler data structure to play with. In the cell bellow, we plot the TargetMapBasis function for the `g` filter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hp.mollview(sim.driver.scheduler.survey_lists[0][1].basis_functions[2]())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/python/lsst/sims/featureScheduler/basis_functions.py
+++ b/python/lsst/sims/featureScheduler/basis_functions.py
@@ -5,7 +5,7 @@ import numpy.ma as ma
 from . import features
 from . import utils
 import healpy as hp
-from lsst.sims.utils import _hpid2RaDec, Site
+from lsst.sims.utils import _hpid2RaDec, Site, _angularSeparation
 from lsst.sims.skybrightness_pre import M5percentiles
 import matplotlib.pylab as plt
 
@@ -37,6 +37,9 @@ class Base_basis_function(object):
     def update_conditions(self, conditions):
         for feature in self.condition_features:
             self.condition_features[feature].update_conditions(conditions)
+
+    def check_feasibility(self):
+        return True
 
     def __call__(self, **kwargs):
         """
@@ -286,7 +289,8 @@ class HADecAltAzPatchBasisFunction(Base_basis_function):
                  patches=({'ha_min': 2., 'ha_max': 22.,
                            'alt_max': 88., 'alt_min': 55.,
                            'dec_min': -90., 'dec_max': 90,
-                           'az_min': 0., 'az_max': 360.},)):
+                           'az_min': 0., 'az_max': 360.,
+                           'weight': 1.},)):
         """
         Parameters
         ----------
@@ -354,7 +358,7 @@ class HADecAltAzPatchBasisFunction(Base_basis_function):
                                                                 alt_mask),
                                                  self.dec_mask[i]),
                                   az_mask)
-            result[mask] = 1.0
+            result[mask] = patch['weight'] if 'weight' in patch else 1.
 
         return result
 
@@ -498,6 +502,74 @@ class Target_map_basis_function(Base_basis_function):
 
         result[indx] = goal_N - self.survey_features['N_obs'].feature[indx]
         result[self.out_of_bounds_area] = self.out_of_bounds_val
+
+        return result
+
+class Normalized_Target_map_basis_function(Base_basis_function):
+    """Normalize the maps first to make things smoother
+    """
+    def __init__(self, filtername='r', nside=default_nside, target_map=None,
+                 survey_features=None, condition_features=None, norm_factor=240./2.5e6,
+                 out_of_bounds_val=-10.):
+        """
+        Parameters
+        ----------
+        filtername: (string 'r')
+            The name of the filter for this target map.
+        nside: int (default_nside)
+            The healpix resolution.
+        target_map : numpy array (None)
+            A healpix map showing the ratio of observations desired for all points on the sky
+        norm_factor : float (800./2.5e6)
+            for converting target map to number of observations. This is a convience scaling,
+            It should be degenerate with the weight of the basis function.
+        out_of_bounds_val : float (10.)
+            Point value to give regions where there are no observations requested
+        """
+        if nside is None:
+            nside = utils.set_default_nside()
+
+        self.norm_factor = norm_factor
+        if survey_features is None:
+            self.survey_features = {}
+            # Map of the number of observations in filter
+            self.survey_features['N_obs'] = features.N_observations(filtername=filtername)
+            # Count of all the observations
+            self.survey_features['N_obs_count_all'] = features.N_obs_count(filtername=None)
+        super(Target_map_basis_function, self).__init__(survey_features=self.survey_features,
+                                                        condition_features=condition_features)
+        self.nside = nside
+        if target_map is None:
+            self.target_map = utils.generate_goal_map(filtername=filtername)
+        else:
+            self.target_map = target_map
+        self.out_of_bounds_area = np.where(self.target_map == 0)[0]
+        self.out_of_bounds_val = out_of_bounds_val
+        self.inside_area = np.where(self.target_map != 0)
+
+    def __call__(self, indx=None):
+        """
+        Parameters
+        ----------
+        indx : list (None)
+            Index values to compute, if None, full map is computed
+        Returns
+        -------
+        Healpix reward map
+        """
+        # Should probably update this to be as masked array.
+        result = np.zeros(hp.nside2npix(self.nside), dtype=float)
+        if indx is None:
+            indx = np.arange(result.size)
+
+        # Find out how many observations we want now at those points
+        goal_N = self.target_map[indx] * self.survey_features['N_obs_count_all'].feature * self.norm_factor
+
+        result[indx] = goal_N - self.survey_features['N_obs'].feature[indx]
+
+        result[self.out_of_bounds_area] = self.out_of_bounds_val
+        norm_val = np.max(result[self.inside_area])
+        result[self.inside_area] -= (norm_val-1.)
 
         return result
 
@@ -732,6 +804,147 @@ class Strict_filter_basis_function(Base_basis_function):
         return result
 
 
+class Goal_Strict_filter_basis_function(Base_basis_function):
+    """Remove the bonus for staying in the same filter if certain conditions are met.
+
+    If the moon rises/sets or twilight starts/ends, it makes a lot of sense to consider
+    a filter change. This basis function rewards if it matches the current filter, the moon rises or sets,
+    twilight starts or stops, or there has been a large gap since the last observation.
+
+    """
+
+    def __init__(self, survey_features=None, condition_features=None, time_lag_min=10., time_lag_max=30.,
+                 time_lag_boost=60., boost_gain=2.0, unseen_before_lag=False,
+                 filtername='r', tag=None, twi_change=-18., proportion=1.0, aways_available=False):
+        """
+        Paramters
+        ---------
+        time_lag : float (10.)
+            If there is a gap between observations longer than this, let the filter change (minutes)
+        twi_change : float (-18.)
+            The sun altitude to consider twilight starting/ending
+        """
+        self.time_lag_min = time_lag_min / 60. / 24.  # Convert to days
+        self.time_lag_max = time_lag_max / 60. / 24.  # Convert to days
+        self.time_lag_boost = time_lag_boost / 60. / 24.
+        self.boost_gain = boost_gain
+        self.unseen_before_lag = unseen_before_lag
+
+        self.twi_change = np.radians(twi_change)
+        self.filtername = filtername
+        self.proportion = proportion
+        self.aways_available = aways_available
+
+        if condition_features is None:
+            self.condition_features = {}
+            self.condition_features['Current_filter'] = features.Current_filter()
+            self.condition_features['Mounted_filter'] = features.Mounted_filters()
+            self.condition_features['Sun_moon_alts'] = features.Sun_moon_alts()
+            self.condition_features['Current_mjd'] = features.Current_mjd()
+        if survey_features is None:
+            self.survey_features = {}
+            self.survey_features['Last_observation'] = features.Last_observation()
+            self.survey_features['N_obs_all'] = features.N_obs_count(filtername=None)
+            self.survey_features['N_obs'] = features.N_obs_count(filtername=filtername,
+                                                                 tag=tag)
+
+        super(Goal_Strict_filter_basis_function, self).__init__(survey_features=self.survey_features,
+                                                           condition_features=self.condition_features)
+
+    def filter_change_bonus(self, time):
+
+        lag_min = self.time_lag_min
+        lag_max = self.time_lag_max
+
+        a = 1. / (lag_max - lag_min)
+        b = -a * lag_min
+
+        bonus = a * time + b
+        # How far behind we are with respect to proportion?
+        nobs = self.survey_features['N_obs'].feature
+        nobs_all = self.survey_features['N_obs_all'].feature
+        goal = self.proportion
+        need = 1. - nobs / nobs_all + goal if nobs_all > 0 else 1. + goal
+        # need /= goal
+        if hasattr(time, '__iter__'):
+            before_lag = np.where(time <= lag_min)
+            bonus[before_lag] = -np.inf if self.unseen_before_lag else 0.
+            after_lag = np.where(time >= lag_max)
+            bonus[after_lag] = 1. if time < self.time_lag_boost else self.boost_gain
+        elif time <= lag_min:
+            return -np.inf if self.unseen_before_lag else 0.
+        elif time >= lag_max:
+            return 1. if time < self.time_lag_boost else self.boost_gain
+
+        return bonus * need
+
+    def check_feasibility(self):
+        if self.condition_features['Current_filter'].feature is None or \
+                self.condition_features['Current_filter'].feature == self.filtername or self.aways_available:
+            return True
+
+        # Did the moon set or rise since last observation?
+        moon_changed = self.condition_features['Sun_moon_alts'].feature['moonAlt'] * \
+                       self.survey_features['Last_observation'].feature['moonAlt'] < 0
+
+        # Are we already in the filter (or at start of night)?
+        not_in_filter = (self.condition_features['Current_filter'].feature != self.filtername)
+
+        # Has enough time past?
+        lag = self.condition_features['Current_mjd'].feature - self.survey_features['Last_observation'].feature['mjd']
+        time_past = lag > self.time_lag_min
+
+        # Did twilight start/end?
+        twi_changed = (self.condition_features['Sun_moon_alts'].feature['sunAlt'] - self.twi_change) * \
+                      (self.survey_features['Last_observation'].feature['sunAlt'] - self.twi_change) < 0
+
+        # Did we just finish a DD sequence
+        wasDD = self.survey_features['Last_observation'].feature['note'] == 'DD'
+
+        # Is the filter mounted?
+        mounted = self.filtername in self.condition_features['Mounted_filter'].feature
+
+        if (moon_changed | time_past | twi_changed | wasDD) & mounted & not_in_filter:
+            return True
+        else:
+            return False
+
+    def __call__(self, **kwargs):
+
+        if self.condition_features['Current_filter'].feature is None:
+            return 0.  # no bonus if no filter is mounted
+        elif self.condition_features['Current_filter'].feature == self.filtername:
+            return 0.  # no bonus if on the filter already
+
+        # Did the moon set or rise since last observation?
+        moon_changed = self.condition_features['Sun_moon_alts'].feature['moonAlt'] * \
+                       self.survey_features['Last_observation'].feature['moonAlt'] < 0
+
+        # Are we already in the filter (or at start of night)?
+        not_in_filter = (self.condition_features['Current_filter'].feature != self.filtername)
+
+        # Has enough time past?
+        lag = self.condition_features['Current_mjd'].feature - self.survey_features['Last_observation'].feature['mjd']
+        time_past = lag > self.time_lag_min
+
+        # Did twilight start/end?
+        twi_changed = (self.condition_features['Sun_moon_alts'].feature['sunAlt'] - self.twi_change) * (
+                    self.survey_features['Last_observation'].feature['sunAlt'] - self.twi_change) < 0
+
+        # Did we just finish a DD sequence
+        wasDD = self.survey_features['Last_observation'].feature['note'] == 'DD'
+
+        # Is the filter mounted?
+        mounted = self.filtername in self.condition_features['Mounted_filter'].feature
+
+        if (moon_changed | time_past | twi_changed | wasDD) & mounted & not_in_filter:
+            result = self.filter_change_bonus(lag) if time_past else 0.
+        else:
+            result = -100. if self.unseen_before_lag else 0.
+
+        return result
+
+
 class Rolling_mask_basis_function(Base_basis_function):
     """Have a simple mask that turns on and off
     """
@@ -833,6 +1046,54 @@ class Slewtime_basis_function(Base_basis_function):
         return result
 
 
+class Agreesive_Slewtime_basis_function(Base_basis_function):
+    """Reward slews that take little time
+    """
+
+    def __init__(self, survey_features=None, condition_features=None,
+                 max_time=135., order=1., hard_max=None, filtername='r', nside=default_nside):
+        if nside is None:
+            nside = utils.set_default_nside()
+
+        self.maxtime = max_time
+        self.hard_max = hard_max
+        self.order = order
+        self.nside = nside
+        self.filtername = filtername
+        if condition_features is None:
+            self.condition_features = {}
+            self.condition_features['Current_filter'] = features.Current_filter()
+            self.condition_features['hp2fields'] = features.HP2Fields()
+            self.condition_features['slewtime'] = features.SlewtimeFeature(nside=nside)
+        super(Agreesive_Slewtime_basis_function, self).__init__(survey_features=survey_features,
+                                                                condition_features=self.condition_features)
+
+    def __call__(self, indx=None):
+        # If we are in a different filter, the Filter_change_basis_function will take it
+        if self.condition_features['Current_filter'].feature != self.filtername:
+            result = 0.
+        else:
+            # Need to make sure smaller slewtime is larger reward.
+            if np.size(self.condition_features['slewtime'].feature) > 1:
+                result = np.empty(np.size(self.condition_features['slewtime'].feature), dtype=float)
+                result.fill(hp.UNSEEN)
+
+                good = np.where(np.bitwise_and(self.condition_features['slewtime'].feature > 0.,
+                                               self.condition_features['slewtime'].feature < self.maxtime))
+                result[good] = ((self.maxtime - self.condition_features['slewtime'].feature[good]) /
+                                self.maxtime) ** self.order
+                if self.hard_max is not None:
+                    not_so_good = np.where(self.condition_features['slewtime'].feature > self.hard_max)
+                    result[not_so_good] -= 10.
+                fields = np.unique(self.condition_features['hp2fields'].feature[good])
+                for field in fields:
+                    hp_indx = np.where(self.condition_features['hp2fields'].feature == field)
+                    result[hp_indx] = np.min(result[hp_indx])
+            else:
+                result = (self.maxtime - self.condition_features['slewtime'].feature) / self.maxtime
+        return result
+
+
 class Bulk_cloud_basis_function(Base_basis_function):
     """Mark healpixels on a map as unseen if their cloud values are greater than
     the same healpixels on a maximum cloud map.
@@ -893,5 +1154,315 @@ class Bulk_cloud_basis_function(Base_basis_function):
 
         clouded = np.where(self.max_cloud_map < self.condition_features['bulk_cloud'].feature)
         result[clouded] = hp.UNSEEN
+
+        return result
+
+
+class Moon_avoidance_basis_function(Base_basis_function):
+    """Mark regions that are closer than a certain .
+
+    """
+    def __init__(self, nside=default_nside, condition_features=None, survey_features=None,
+                 moon_distance=30.):
+        """
+        Parameters
+        moon_distance: float (30.)
+            Minimum allowed moon distance. (degrees)
+        """
+        if nside is None:
+            nside = utils.set_default_nside()
+
+        self.nside = nside
+        if survey_features is None:
+            self.survey_features = {}
+        if condition_features is None:
+            self.condition_features = dict()
+            self.condition_features['altaz'] = features.AltAzFeature(nside=nside)
+            self.condition_features['lmst'] = features.Current_lmst()
+            self.condition_features['moon'] = features.Moon()
+
+        self.moon_distance = np.radians(moon_distance)
+
+    def __call__(self, indx=None):
+        result = np.ones(hp.nside2npix(self.nside), dtype=float)
+
+        alt = self.condition_features['altaz'].feature['alt']
+        az = self.condition_features['altaz'].feature['az']
+
+        angular_distance = _angularSeparation(az, alt,
+                                              self.condition_features['moon'].feature['moonAz'],
+                                              self.condition_features['moon'].feature['moonAlt'])
+
+        result[angular_distance < self.moon_distance] = hp.UNSEEN
+
+        return result
+
+
+class Skybrightness_limit_basis_function(Base_basis_function):
+    """Mark regions that are closer than a certain .
+
+    """
+    def __init__(self, nside=default_nside, condition_features=None, survey_features=None,
+                 filtername='r', min=20., max=30.):
+        """
+        Parameters
+        moon_distance: float (30.)
+            Minimum allowed moon distance. (degrees)
+        """
+        if nside is None:
+            nside = utils.set_default_nside()
+
+        self.min = min
+        self.max = max
+        self.nside = nside
+        if survey_features is None:
+            self.survey_features = {}
+        if condition_features is None:
+            self.condition_features = dict()
+            self.condition_features['skybrightness'] = features.SkyBrightness(filtername=filtername, nside=nside)
+
+    def __call__(self, indx=None):
+        result = np.empty(hp.nside2npix(self.nside), dtype=float)
+        result.fill(hp.UNSEEN)
+
+        good = np.where(np.bitwise_and(self.condition_features['skybrightness'].feature > self.min,
+                                       self.condition_features['skybrightness'].feature < self.max))
+        result[good] = 1.0
+
+        return result
+
+
+class HourAngle_bonus_basis_function(Base_basis_function):
+    """Hour angle bonus basis function
+
+    """
+    def __init__(self, nside=default_nside, condition_features=None, survey_features=None,
+                 max_hourangle=6., minAlt=20., maxAlt=82.):
+        """
+        Parameters
+        ----------
+        """
+        if nside is None:
+            nside = utils.set_default_nside()
+
+        self.nside = nside
+        if survey_features is None:
+            self.survey_features = {}
+        if condition_features is None:
+            self.condition_features = dict()
+            self.condition_features['lmst'] = features.Current_lmst()
+            self.condition_features['altaz'] = features.AltAzFeature(nside=nside)
+
+        ra, dec = utils.ra_dec_hp_map(self.nside)
+        self.ra_hours = ra*12./np.pi % 24.
+        self.max_hourangle = max_hourangle
+        self.minAlt = np.radians(minAlt)
+        self.maxAlt = np.radians(maxAlt)
+
+    def __call__(self, indx=None):
+        result = np.empty(hp.nside2npix(self.nside), dtype=float)
+        result.fill(hp.UNSEEN)
+
+        ha = (self.condition_features['lmst'].feature - self.ra_hours) % 24.
+
+        # Make hour angle go from -12 to 12 instead of 0 to 24
+        mask = np.where(ha > 12.)
+        ha[mask] -= 24.
+
+        alt = self.condition_features['altaz'].feature['alt']
+
+        mask = np.where((np.abs(ha) < self.max_hourangle) & (alt < self.maxAlt) & (alt > self.minAlt))
+        result[mask] = (1 - np.abs(ha[mask]) / self.max_hourangle)
+
+        return result
+
+
+class NorthSouth_scan_basis_function(Base_basis_function):
+    """
+    """
+    def __init__(self, nside=default_nside, condition_features=None, minAlt=20., maxAlt=82.,
+                 length=70., survey_features=None):
+        """
+        Parameters
+        ----------
+        minAlt : float (20.)
+            The minimum altitude to consider (degrees)
+        maxAlt : float (82.)
+            The maximum altitude to leave unmasked (degrees)
+        length: float (90.)
+            The lenght of the scanning region in N/S direction (degrees)
+        """
+        if nside is None:
+            nside = utils.set_default_nside()
+
+        self.length = np.radians(length)
+        self.current_direction = 0
+        self.directions = ['NS', 'SN']
+
+        if survey_features is None:
+            self.survey_features = {}
+        if condition_features is None:
+            self.condition_features = {}
+            self.condition_features['altaz'] = features.AltAzFeature()
+            self.condition_features['current_pointing'] = features.Current_pointing()
+        self.minAlt = np.radians(minAlt)
+        self.maxAlt = np.radians(maxAlt)
+        # Convert to half-width for convienence
+        self.nside = nside
+
+    def __call__(self, indx=None):
+
+        result = np.empty(hp.nside2npix(self.nside), dtype=float)
+        result.fill(hp.UNSEEN)
+
+        # How far north/south the telescope is pointing
+        tel_ns_axis = np.cos(self.condition_features['current_pointing'].feature['az']) * \
+                      (np.radians(90.)-self.condition_features['current_pointing'].feature['alt'])
+
+        alt = self.condition_features['altaz'].feature['alt']
+        az = self.condition_features['altaz'].feature['az']
+
+        ns_axis = np.cos(az)*(np.radians(90.)-alt)
+        # If reached limit, switch direction
+        if self.current_direction == 0 and tel_ns_axis > self.length:
+            self.current_direction = (self.current_direction + 1) % len(self.directions)
+        elif self.current_direction == 1 and tel_ns_axis < self.length:
+            self.current_direction = (self.current_direction + 1) % len(self.directions)
+
+        if self.current_direction == 0:
+            result[ns_axis > tel_ns_axis] = 0.
+            a = 1./(tel_ns_axis+self.length)
+            b = self.length*a
+            result[ns_axis <= tel_ns_axis] = (a*ns_axis[ns_axis <= tel_ns_axis] + b)
+        else:
+            result[ns_axis < tel_ns_axis] = 0.
+            a = 1./(tel_ns_axis-self.length)
+            b = -self.length*a
+            result[ns_axis >= tel_ns_axis] = (a*ns_axis[ns_axis >= tel_ns_axis] + b)
+
+        alt_limit = np.where((alt < self.minAlt) |
+                             (alt > self.maxAlt))
+
+        result[alt_limit] = hp.UNSEEN
+
+        return result
+
+
+class CableWrap_unwrap_basis_function(Base_basis_function):
+    """
+    """
+    def __init__(self, nside=default_nside, condition_features=None, minAz=-270., maxAz=270., minAlt=20., maxAlt=82.,
+                 activate_tol=20., delta_unwrap=1.2, unwrap_until=70., max_duration=30., survey_features=None):
+        """
+        Parameters
+        ----------
+        minAz : float (20.)
+            The minimum azimuth to activite bf (degrees)
+        maxAz : float (82.)
+            The maximum azimuth to activate bf (degrees)
+        unwrap_until: float (90.)
+            The window in which the bf is activated (degrees)
+        """
+        if nside is None:
+            nside = utils.set_default_nside()
+
+        if survey_features is None:
+            self.survey_features = {}
+        if condition_features is None:
+            self.condition_features = {}
+            self.condition_features['altaz'] = features.AltAzFeature()
+            self.condition_features['current_pointing'] = features.Current_pointing()
+            self.condition_features['mjd'] = features.Current_mjd()
+
+        self.minAz = np.radians(minAz)
+        self.maxAz = np.radians(maxAz)
+
+        self.activate_tol = np.radians(activate_tol)
+        self.delta_unwrap = np.radians(delta_unwrap)
+        self.unwrap_until = np.radians(unwrap_until)
+
+        self.minAlt = np.radians(minAlt)
+        self.maxAlt = np.radians(maxAlt)
+        # Convert to half-width for convienence
+        self.nside = nside
+        self.active = False
+        self.unwrap_direction = 0.  # either -1., 0., 1.
+        self.max_duration = max_duration/60./24.  # Convert to days
+        self.activation_time = None
+
+    def __call__(self, indx=None):
+
+        result = np.zeros(hp.nside2npix(self.nside), dtype=float)
+        alt = self.condition_features['altaz'].feature['alt']
+        current_abs_rad = np.radians(self.condition_features['current_pointing'].feature['az'])
+        unseen = np.where(np.bitwise_or(alt < self.minAlt,
+                                        alt > self.maxAlt))
+        result[unseen] = hp.UNSEEN
+
+        if (self.minAz + self.activate_tol < current_abs_rad < self.maxAz - self.activate_tol) and not self.active:
+            return result
+        elif self.active and self.unwrap_direction == 1 and current_abs_rad > self.minAz+self.unwrap_until:
+            self.active = False
+            self.unwrap_direction = 0.
+            self.activation_time = None
+            return result
+        elif self.active and self.unwrap_direction == -1 and current_abs_rad < self.maxAz-self.unwrap_until:
+            self.active = False
+            self.unwrap_direction = 0.
+            self.activation_time = None
+            return result
+        elif (self.activation_time is not None and
+              self.condition_features['mjd'].feature - self.activation_time > self.max_duration):
+            self.active = False
+            self.unwrap_direction = 0.
+            self.activation_time = None
+            return result
+
+        az_rad = self.condition_features['altaz'].feature['az']
+
+        if not self.active:
+            self.activation_time = self.condition_features['mjd'].feature
+            if current_abs_rad < 0.:
+                self.unwrap_direction = 1  # clock-wise unwrap
+            else:
+                self.unwrap_direction = -1  # counter-clock-wise unwrap
+
+        self.active = True
+
+        max_abs_rad = self.maxAz
+        min_abs_rad = self.minAz
+
+        TWOPI = 2.*np.pi
+
+        # Compute distance and accumulated az.
+        norm_az_rad = np.divmod(az_rad - min_abs_rad, TWOPI)[1] + min_abs_rad
+        distance_rad = divmod(norm_az_rad - current_abs_rad, TWOPI)[1]
+        get_shorter = np.where(distance_rad > np.pi)
+        distance_rad[get_shorter] -= TWOPI
+        accum_abs_rad = current_abs_rad + distance_rad
+
+        # Compute wrap regions and fix distances
+        mask_max = np.where(accum_abs_rad > max_abs_rad)
+        distance_rad[mask_max] -= TWOPI
+        mask_min = np.where(accum_abs_rad < min_abs_rad)
+        distance_rad[mask_min] += TWOPI
+
+        # Step-2: Repeat but now with compute reward to unwrap using specified delta_unwrap
+        unwrap_current_abs_rad = current_abs_rad - (np.abs(self.delta_unwrap) if self.unwrap_direction > 0
+            else -np.abs(self.delta_unwrap))
+        unwrap_distance_rad = divmod(norm_az_rad - unwrap_current_abs_rad, TWOPI)[1]
+        unwrap_get_shorter = np.where(unwrap_distance_rad > np.pi)
+        unwrap_distance_rad[unwrap_get_shorter] -= TWOPI
+        unwrap_distance_rad = np.abs(unwrap_distance_rad)
+
+        if self.unwrap_direction < 0:
+            mask = np.where(accum_abs_rad > unwrap_current_abs_rad)
+        else:
+            mask = np.where(accum_abs_rad < unwrap_current_abs_rad)
+
+        # Finally build reward map
+        result = (1. - unwrap_distance_rad/np.max(unwrap_distance_rad))**2.
+        result[mask] = 0.
+        result[unseen] = hp.UNSEEN
 
         return result

--- a/python/lsst/sims/featureScheduler/core_scheduler.py
+++ b/python/lsst/sims/featureScheduler/core_scheduler.py
@@ -133,13 +133,13 @@ class Core_scheduler(object):
             for i, survey in enumerate(surveys):
                 rewards[i] = np.max(survey.calc_reward_function())
             # If we have a good reward, break out of the loop
-            if np.nanmax(rewards) > -np.inf:
+            if np.nanmax(rewards) > -np.inf and np.nanmax(rewards) > hp.UNSEEN:
                 self.survey_index[0] = ns
                 break
 
         # Take a min here, so the surveys will be executed in the order they are
         # entered if there is a tie.
-        if np.all(np.bitwise_or(np.isnan(rewards), np.isneginf(rewards))):
+        if np.all(np.bitwise_or(np.bitwise_or(np.isnan(rewards), np.isneginf(rewards)), rewards == hp.UNSEEN)):
             # All values are invalid
             self._clean_queue()
         else:
@@ -162,7 +162,7 @@ class Core_scheduler(object):
         """
         self.queue = []
         self.is_sequence = False
-        self.survey_index = None
+        self.survey_index = [0, 0]
 
 class Core_scheduler_parallel(Core_scheduler):
     """Execute survey methods in parallel

--- a/python/lsst/sims/featureScheduler/driver/config/config.py
+++ b/python/lsst/sims/featureScheduler/driver/config/config.py
@@ -56,25 +56,18 @@ cloud_map = fs.utils.generate_cloud_map(target_maps, filtername='r',
                                         gp_cloud_max=0.7,
                                         nes_cloud_max=0.7)
 
-# x1 = 30.
-# x0 = 2.
-# B = x1 / (x1 - x0)
-# A = -B / x1
-# width = np.arange(x0, x1, 0.5)
-# z_pad = width + 8.
-# weight = (A * width + B)
-# height = np.zeros_like(width) + 80.
-
-width = (10.,)
-z_pad = (18.,)
-weight = (1.,)
-height = (80.,)
+# Parameters for MeridianStripeBasisFunction.
+width = (10.,)  # The width of the meridian mask.
+z_pad = (18.,)  # The radius of the zenith pad.
+weight = (1.,)  # The weight of the mask.
+height = (80.,)  # The height (distance from zenith to North/South) of the mask.
 
 filters = ['u', 'g', 'r', 'i', 'z', 'y']
 surveys = []
 
 sb_limit_map = fs.utils.generate_sb_map(target_maps, filters)
 
+# The proportion of the number of visits on each filter.
 filter_prop = {'u': 0.069,
                'g': 0.097,
                'r': 0.222,
@@ -100,14 +93,14 @@ for filtername in filters:
     # bfs.append(fs.HADecAltAzPatchBasisFunction(nside=nside,
     #                                            patches=patches[::-1]))
     bfs.append(fs.Slewtime_basis_function(filtername=filtername, nside=nside, order=6., hard_max=20.))
-    bfs.append(fs.Strict_filter_basis_function(filtername=filtername,
-                                               time_lag_min=90.,
-                                               time_lag_max=150.,
-                                               time_lag_boost=180.,
-                                               boost_gain=1.0,
-                                               unseen_before_lag=True,
-                                               proportion=filter_prop[filtername],
-                                               aways_available=filtername in 'zy'))
+    bfs.append(fs.Goal_Strict_filter_basis_function(filtername=filtername,
+                                                    time_lag_min=90.,
+                                                    time_lag_max=150.,
+                                                    time_lag_boost=180.,
+                                                    boost_gain=1.0,
+                                                    unseen_before_lag=True,
+                                                    proportion=filter_prop[filtername],
+                                                    aways_available=filtername in 'zy'))
     bfs.append(fs.Avoid_Fast_Revists(filtername=None, gap_min=240., nside=nside))
     bfs.append(fs.Bulk_cloud_basis_function(max_cloud_map=cloud_map, nside=nside))
     bfs.append(fs.Moon_avoidance_basis_function(nside=nside, moon_distance=40.))

--- a/python/lsst/sims/featureScheduler/driver/config/config.py
+++ b/python/lsst/sims/featureScheduler/driver/config/config.py
@@ -14,106 +14,207 @@ target_maps = {}
 nside = fs.set_default_nside(nside=32)  # Required
 
 target_maps['u'] = fs.generate_goal_map(NES_fraction=0.,
-                                        WFD_fraction=0.31, SCP_fraction=0.15,
-                                        GP_fraction=0.15, nside=nside,
+                                        WFD_fraction=0.31, SCP_fraction=0.08,
+                                        GP_fraction=0.004,
+                                        WFD_upper_edge_fraction=0.0,
+                                        nside=nside,
                                         generate_id_map=True)
 target_maps['g'] = fs.generate_goal_map(NES_fraction=0.2,
-                                        WFD_fraction=0.44, SCP_fraction=0.15,
-                                        GP_fraction=0.15, nside=nside,
+                                        WFD_fraction=0.44, SCP_fraction=0.08,
+                                        GP_fraction=0.004,
+                                        WFD_upper_edge_fraction=0.0,
+                                        nside=nside,
                                         generate_id_map=True)
 target_maps['r'] = fs.generate_goal_map(NES_fraction=0.46,
-                                        WFD_fraction=1.0, SCP_fraction=0.15,
-                                        GP_fraction=0.15, nside=nside,
+                                        WFD_fraction=1.0, SCP_fraction=0.08,
+                                        WFD_upper_edge_fraction=0.0,
+                                        GP_fraction=0.004,
+                                        nside=nside,
                                         generate_id_map=True)
 target_maps['i'] = fs.generate_goal_map(NES_fraction=0.46,
-                                        WFD_fraction=1.0, SCP_fraction=0.15,
-                                        GP_fraction=0.15, nside=nside,
+                                        WFD_fraction=1.0, SCP_fraction=0.08,
+                                        GP_fraction=0.004,
+                                        WFD_upper_edge_fraction=0.0,
+                                        nside=nside,
                                         generate_id_map=True)
 target_maps['z'] = fs.generate_goal_map(NES_fraction=0.4,
-                                        WFD_fraction=0.9, SCP_fraction=0.15,
-                                        GP_fraction=0.15, nside=nside,
+                                        WFD_fraction=0.9, SCP_fraction=0.08,
+                                        GP_fraction=0.004,
+                                        WFD_upper_edge_fraction=0.0,
+                                        nside=nside,
                                         generate_id_map=True)
 target_maps['y'] = fs.generate_goal_map(NES_fraction=0.,
-                                        WFD_fraction=0.9, SCP_fraction=0.15,
-                                        GP_fraction=0.15, nside=nside,
+                                        WFD_fraction=0.9, SCP_fraction=0.08,
+                                        GP_fraction=0.004,
+                                        WFD_upper_edge_fraction=0.0,
+                                        nside=nside,
                                         generate_id_map=True)
+
+cloud_map = fs.utils.generate_cloud_map(target_maps, filtername='r',
+                                        wfd_cloud_max=0.7,
+                                        scp_cloud_max=0.7,
+                                        gp_cloud_max=0.7,
+                                        nes_cloud_max=0.7)
+
+# x1 = 30.
+# x0 = 2.
+# B = x1 / (x1 - x0)
+# A = -B / x1
+# width = np.arange(x0, x1, 0.5)
+# z_pad = width + 8.
+# weight = (A * width + B)
+# height = np.zeros_like(width) + 80.
+
+width = (10.,)
+z_pad = (18.,)
+weight = (1.,)
+height = (80.,)
 
 filters = ['u', 'g', 'r', 'i', 'z', 'y']
 surveys = []
 
+sb_limit_map = fs.utils.generate_sb_map(target_maps, filters)
+
+filter_prop = {'u': 0.069,
+               'g': 0.097,
+               'r': 0.222,
+               'i': 0.222,
+               'z': 0.194,
+               'y': 0.194}
+
 for filtername in filters:
-    bfs = []
-    bfs.append(fs.M5_diff_basis_function(filtername=filtername, nside=nside))
+    bfs = list()
+    # bfs.append(fs.M5_diff_basis_function(filtername=filtername, nside=nside))
+    bfs.append(fs.HourAngle_bonus_basis_function(max_hourangle=3.))
+    bfs.append(fs.Skybrightness_limit_basis_function(nside=nside,
+                                                     filtername=filtername,
+                                                     min=sb_limit_map[filtername]['min'],
+                                                     max=sb_limit_map[filtername]['max']))
     bfs.append(fs.Target_map_basis_function(filtername=filtername,
                                             target_map=target_maps[filtername][0],
                                             out_of_bounds_val=hp.UNSEEN, nside=nside))
+    bfs.append(fs.MeridianStripeBasisFunction(nside=nside,width=width,
+                                              weight=weight,
+                                              height=height,
+                                              zenith_pad=z_pad))
+    # bfs.append(fs.HADecAltAzPatchBasisFunction(nside=nside,
+    #                                            patches=patches[::-1]))
+    bfs.append(fs.Slewtime_basis_function(filtername=filtername, nside=nside, order=6., hard_max=20.))
+    bfs.append(fs.Strict_filter_basis_function(filtername=filtername,
+                                               time_lag_min=90.,
+                                               time_lag_max=150.,
+                                               time_lag_boost=180.,
+                                               boost_gain=1.0,
+                                               unseen_before_lag=True,
+                                               proportion=filter_prop[filtername],
+                                               aways_available=filtername in 'zy'))
+    bfs.append(fs.Avoid_Fast_Revists(filtername=None, gap_min=240., nside=nside))
+    bfs.append(fs.Bulk_cloud_basis_function(max_cloud_map=cloud_map, nside=nside))
+    bfs.append(fs.Moon_avoidance_basis_function(nside=nside, moon_distance=40.))
+    # bfs.append(fs.CableWrap_unwrap_basis_function(nside=nside, activate_tol=70., unwrap_until=315,
+    #                                               max_duration=90.))
+    # bfs.append(fs.NorthSouth_scan_basis_function(length=70.))
 
-    bfs.append(fs.MeridianStripeBasisFunction(nside=nside, width=(8.,)))
-    bfs.append(fs.Slewtime_basis_function(filtername=filtername, nside=nside))
-    bfs.append(fs.Strict_filter_basis_function(filtername=filtername))
-    bfs.append(fs.Avoid_Fast_Revists(filtername=filtername, gap_min=240., nside=nside))
-
-    weights = np.array([3.0, 0.5, 1., 3., 3., 3.])
-    # surveys.append(fs.Greedy_survey_fields(bfs, weights, block_size=1, filtername=filtername, dither=False,
-    #                                        nside=nside, smoothing_kernel=9,
-    #                                        tag_fields=True, tag_map=target_maps[filtername][1]))
-    surveys.append(fs.Greedy_survey_fields(bfs, weights, block_size=1, filtername=filtername, dither=True,
+    weights = np.array([2., 0.1, .1, 1., 3., 1.5, 1.0, 1.0, 1.0])
+    surveys.append(fs.Greedy_survey_fields(bfs, weights, block_size=1,
+                                           filtername=filtername, dither=True,
                                            nside=nside,
                                            tag_fields=True,
                                            tag_map=target_maps[filtername][1],
-                                           tag_names=target_maps[filtername][2]))
+                                           tag_names=target_maps[filtername][2],
+                                           ignore_obs='DD'))
 
 # Set up pairs
-surveys.append(fs.Pairs_survey_scripted([], [], ignore_obs='DD'))
+pairs_bfs = []
+
+pair_map = np.zeros(len(target_maps['z'][0]))
+pair_map.fill(hp.UNSEEN)
+wfd = np.where(target_maps['z'][1] == 3)
+nes = np.where(target_maps['z'][1] == 1)
+pair_map[wfd] = 1.
+pair_map[nes] = 1.
+
+pairs_bfs.append(fs.Target_map_basis_function(filtername='',
+                                              target_map=pair_map,
+                                              out_of_bounds_val=hp.UNSEEN, nside=nside))
+pairs_bfs.append(fs.MeridianStripeBasisFunction(nside=nside, zenith_pad=(45.,), width=(35.,)))
+pairs_bfs.append(fs.Moon_avoidance_basis_function(nside=nside, moon_distance=30.))
+
+# surveys.append(fs.Pairs_survey_scripted(pairs_bfs, [1., 1., 1.], ignore_obs='DD', min_alt=20.))
+surveys.append(fs.Pairs_different_filters_scripted(pairs_bfs, [1., 1., 1.], ignore_obs='DD', min_alt=20.,
+                                                   filter_goals=filter_prop))
+# surveys.append(fs.Pairs_survey_scripted([], [], ignore_obs='DD'))
 
 # Set up the DD
 # ELAIS S1
 surveys.append(fs.Deep_drilling_survey(9.45, -44., sequence='rgizy',
-                                    nvis=[20, 10, 20, 26, 20],
-                                    survey_name='DD:ELAISS1', reward_value=100, moon_up=None,
-                                    fraction_limit=0.0185, ha_limits=([0., 0.5], [23.5, 24.]),
-                                    nside=nside))
+                                       nvis=[20, 10, 20, 26, 20],
+                                       survey_name='DD:ELAISS1', reward_value=100, moon_up=None,
+                                       fraction_limit=0.148, ha_limits=([0., 0.5], [23.5, 24.]),
+                                       nside=nside,
+                                       avoid_same_day=True,
+                                       filter_goals=filter_prop))
 surveys.append(fs.Deep_drilling_survey(9.45, -44., sequence='u',
-                                    nvis=[7],
-                                    survey_name='DD:u,ELAISS1', reward_value=100, moon_up=False,
-                                    fraction_limit=0.0015, ha_limits=([0., 0.5], [23.5, 24.]),
-                                    nside=nside))
+                                       nvis=[7],
+                                       survey_name='DD:u,ELAISS1', reward_value=100, moon_up=False,
+                                       fraction_limit=0.0012, ha_limits=([0., 0.5], [23.5, 24.]),
+                                       nside=nside))
 
 # XMM-LSS
-surveys.append(fs.Deep_drilling_survey(35.708333, -4-45/60., sequence='rgizy',
-                                    nvis=[20, 10, 20, 26, 20],
-                                    survey_name='DD:XMM-LSS', reward_value=100, moon_up=None,
-                                    fraction_limit=0.0185, ha_limits=([0., 0.5], [23.5, 24.]),
-                                    nside=nside))
-surveys.append(fs.Deep_drilling_survey(35.708333, -4-45/60., sequence='u',
-                                    nvis=[7],
-                                    survey_name='DD:u,XMM-LSS', reward_value=100, moon_up=False,
-                                    fraction_limit=0.0015, ha_limits=([0., 0.5], [23.5, 24.]),
-                                    nside=nside))
+surveys.append(fs.Deep_drilling_survey(35.708333, -4 - 45 / 60., sequence='rgizy',
+                                       nvis=[20, 10, 20, 26, 20],
+                                       survey_name='DD:XMM-LSS', reward_value=100, moon_up=None,
+                                       fraction_limit=0.148, ha_limits=([0., 0.5], [23.5, 24.]),
+                                       nside=nside,
+                                       avoid_same_day=True,
+                                       filter_goals=filter_prop))
+surveys.append(fs.Deep_drilling_survey(35.708333, -4 - 45 / 60., sequence='u',
+                                       nvis=[7],
+                                       survey_name='DD:u,XMM-LSS', reward_value=100, moon_up=False,
+                                       fraction_limit=0.0012, ha_limits=([0., 0.5], [23.5, 24.]),
+                                       nside=nside))
 
 # Extended Chandra Deep Field South
 # XXX--Note, this one can pass near zenith. Should go back and add better planning on this.
-surveys.append(fs.Deep_drilling_survey(53.125, -28.-6/60., sequence='rgizy',
-                                    nvis=[20, 10, 20, 26, 20],
-                                    survey_name='DD:ECDFS', reward_value=100, moon_up=None,
-                                    fraction_limit=0.0185, ha_limits=[[0.5, 1.0], [23., 22.5]],
-                                    nside=nside))
-surveys.append(fs.Deep_drilling_survey(53.125, -28.-6/60., sequence='u',
-                                    nvis=[7],
-                                    survey_name='DD:u,ECDFS', reward_value=100, moon_up=False,
-                                    fraction_limit=0.0015, ha_limits=[[0.5, 1.0], [23., 22.5]],
-                                    nside=nside))
+surveys.append(fs.Deep_drilling_survey(53.125, -28. - 6 / 60., sequence='rgizy',
+                                       nvis=[20, 10, 20, 26, 20],
+                                       survey_name='DD:ECDFS', reward_value=100, moon_up=None,
+                                       fraction_limit=0.148, ha_limits=[[0.5, 1.0], [23., 22.5]],
+                                       nside=nside,
+                                       avoid_same_day=True,
+                                       filter_goals=filter_prop))
+surveys.append(fs.Deep_drilling_survey(53.125, -28. - 6 / 60., sequence='u',
+                                       nvis=[7],
+                                       survey_name='DD:u,ECDFS', reward_value=100, moon_up=False,
+                                       fraction_limit=0.0012, ha_limits=[[0.5, 1.0], [23., 22.5]],
+                                       nside=nside))
 # COSMOS
-surveys.append(fs.Deep_drilling_survey(150.1, 2.+10./60.+55/3600., sequence='rgizy',
-                                    nvis=[20, 10, 20, 26, 20],
-                                    survey_name='DD:COSMOS', reward_value=100, moon_up=None,
-                                    fraction_limit=0.0185, ha_limits=([0., 0.5], [23.5, 24.]),
-                                    nside=nside))
-surveys.append(fs.Deep_drilling_survey(150.1, 2.+10./60.+55/3600., sequence='u',
-                                    nvis=[7], ha_limits=([0., .5], [23.5, 24.]),
-                                    survey_name='DD:u,COSMOS', reward_value=100, moon_up=False,
-                                    fraction_limit=0.0015,
-                                    nside=nside))
+surveys.append(fs.Deep_drilling_survey(150.1, 2. + 10. / 60. + 55 / 3600., sequence='rgizy',
+                                       nvis=[20, 10, 20, 26, 20],
+                                       survey_name='DD:COSMOS', reward_value=100, moon_up=None,
+                                       fraction_limit=0.148, ha_limits=([0., 0.5], [23.5, 24.]),
+                                       nside=nside,
+                                       avoid_same_day=True,
+                                       filter_goals=filter_prop))
+surveys.append(fs.Deep_drilling_survey(150.1, 2. + 10. / 60. + 55 / 3600., sequence='u',
+                                       nvis=[7], ha_limits=([0., .5], [23.5, 24.]),
+                                       survey_name='DD:u,COSMOS', reward_value=100, moon_up=False,
+                                       fraction_limit=0.0012,
+                                       nside=nside))
 
+# Extra DD Field, just to get to 5. Still not closed on this one
+surveys.append(fs.Deep_drilling_survey(349.386443, -63.321004, sequence='rgizy',
+                                       nvis=[20, 10, 20, 26, 20],
+                                       survey_name='DD:290', reward_value=100, moon_up=None,
+                                       fraction_limit=0.148, ha_limits=([0., 0.5], [23.5, 24.]),
+                                       nside=nside,
+                                       avoid_same_day=True,
+                                       filter_goals=filter_prop))
+surveys.append(fs.Deep_drilling_survey(349.386443, -63.321004, sequence='u',
+                                       nvis=[7],
+                                       survey_name='DD:u,290', reward_value=100, moon_up=False,
+                                       fraction_limit=0.0012, ha_limits=([0., 0.5], [23.5, 24.]),
+                                       nside=nside,
+                                       filter_goals=filter_prop))
 
 scheduler = fs.Core_scheduler(surveys, nside=nside)  # Required

--- a/python/lsst/sims/featureScheduler/driver/driver.py
+++ b/python/lsst/sims/featureScheduler/driver/driver.py
@@ -302,6 +302,7 @@ class FeatureSchedulerDriver(Driver):
             self.scheduler.flush_queue()
             self.targetid -= 1
             self.last_winner_target = self.nulltarget
+            self.scheduler_winner_target = None
 
         self.log.debug(self.last_winner_target)
         # for propid in self.proposal_id_dict.keys():
@@ -458,7 +459,7 @@ class FeatureSchedulerDriver(Driver):
                                          self.observatoryModel.location.latitude_rad,
                                          self.observatoryModel.location.longitude_rad,
                                          self.observatoryModel.dateprofile.mjd,
-                                         self.observatoryModel.dateprofile.lst_rad)
+                                         self.observatoryModel.dateprofile.lst_rad * 12. / np.pi % 24.)
         current_filter = self.observatoryModel.current_state.filter
 
         lax_dome = self.observatoryModel.params.domaz_free_range > 0.

--- a/python/lsst/sims/featureScheduler/driver/driver.py
+++ b/python/lsst/sims/featureScheduler/driver/driver.py
@@ -99,18 +99,25 @@ class FeatureSchedulerDriver(Driver):
         else:
             configure_path = os.path.join(kwargs['config_path'], CONFIG_NAME)
 
-        if os.path.exists(configure_path):
-            self.log.info('Loading feature based scheduler configuration from {}.'.format(configure_path))
-            spec = importlib.util.spec_from_file_location("config", configure_path)
-            conf = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(conf)
-            # conf = None
-        else:
-            self.log.info('Loading feature based scheduler default configuration.')
-            conf = import_module('lsst.sims.featureScheduler.driver.config')
+        force = kwargs.pop('force', False)
+        survey_topology = None
 
-        self.scheduler = conf.scheduler
-        self.sky_nside = conf.nside
+        if self.scheduler is None or force:
+            if os.path.exists(configure_path):
+                self.log.info('Loading feature based scheduler configuration from {}.'.format(configure_path))
+                spec = importlib.util.spec_from_file_location("config", configure_path)
+                conf = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(conf)
+                # conf = None
+            else:
+                self.log.info('Loading feature based scheduler default configuration.')
+                conf = import_module('lsst.sims.featureScheduler.driver.config')
+
+            self.scheduler = conf.scheduler
+            self.sky_nside = conf.nside
+            survey_topology = conf.survey_topology
+        else:
+            self.log.info('Scheduler already configured.')
 
         for survey_list in self.scheduler.survey_lists:
             for survey in survey_list:
@@ -129,7 +136,7 @@ class FeatureSchedulerDriver(Driver):
 
         self.initialized = True
 
-        return conf.survey_topology
+        return survey_topology
 
     def end_survey(self):
 
@@ -433,9 +440,9 @@ class FeatureSchedulerDriver(Driver):
         telemetry_stream['mounted_filters'] = copy.copy(self.observatoryModel.current_state.mountedfilters)
         telemetry_stream['telRA'] = copy.copy(np.degrees(self.observatoryModel.current_state.ra_rad))
         telemetry_stream['telDec'] = copy.copy(np.degrees(self.observatoryModel.current_state.dec_rad))
-        telemetry_stream['telAlt'] = copy.copy(np.degrees(self.observatoryModel.current_state.alt_rad))
-        telemetry_stream['telAz'] = copy.copy(np.degrees(self.observatoryModel.current_state.az_rad))
-        telemetry_stream['telRot'] = copy.copy(np.degrees(self.observatoryModel.current_state.rot_rad))
+        telemetry_stream['telAlt'] = copy.copy(np.degrees(self.observatoryModel.current_state.telalt_rad))
+        telemetry_stream['telAz'] = copy.copy(np.degrees(self.observatoryModel.current_state.telaz_rad))
+        telemetry_stream['telRot'] = copy.copy(np.degrees(self.observatoryModel.current_state.telrot_rad))
 
         # What is the sky brightness over the sky (healpix map)
         telemetry_stream['skybrightness'] = copy.copy(
@@ -454,8 +461,10 @@ class FeatureSchedulerDriver(Driver):
                                          self.observatoryModel.dateprofile.lst_rad)
         current_filter = self.observatoryModel.current_state.filter
 
+        lax_dome = self.observatoryModel.params.domaz_free_range > 0.
         telemetry_stream['slewtimes'] = copy.copy(self.observatoryModel.get_approximate_slew_delay(alt, az,
-                                                                                         current_filter))
+                                                                                                   current_filter,
+                                                                                                   lax_dome=lax_dome))
         # What is the airmass over the sky (healpix map).
 
         telemetry_stream['airmass'] = copy.copy(
@@ -471,9 +480,17 @@ class FeatureSchedulerDriver(Driver):
             telemetry_stream['FWHMeff_%s' % filtername] = copy.copy(fwhm_effective[i])  # arcsec
             telemetry_stream['FWHM_geometric_%s' % filtername] = copy.copy(fwhm_geometric[i])
 
-        sunMoon_info = self.sky_brightness.returnSunMoon(self.observatoryModel.dateprofile.mjd)
+        self.sky.update(self.time)
+
+        sunMoon_info = self.sky.get_moon_sun_info(np.array([0.0]), np.array([0.0]))
+
         # Pretty sure these are radians
         telemetry_stream['sunAlt'] = copy.copy(np.max(sunMoon_info['sunAlt']))
         telemetry_stream['moonAlt'] = copy.copy(np.max(sunMoon_info['moonAlt']))
+
+        telemetry_stream['moonAz'] = copy.copy(np.max(sunMoon_info['moonAz']))
+        telemetry_stream['moonRA'] = copy.copy(np.max(sunMoon_info['moonRA']))
+        telemetry_stream['moonDec'] = copy.copy(np.max(sunMoon_info['moonDec']))
+        telemetry_stream['moonPhase'] = copy.copy(np.max(sunMoon_info['moonPhase']))
 
         return telemetry_stream

--- a/python/lsst/sims/featureScheduler/features.py
+++ b/python/lsst/sims/featureScheduler/features.py
@@ -83,17 +83,26 @@ class BulkCloudCover(BaseConditionsFeature):
 class N_obs_count(BaseSurveyFeature):
     """Count the number of observations.
     """
-    def __init__(self, filtername=None):
+    def __init__(self, filtername=None, tag=None):
         self.feature = 0
         self.filtername = filtername
+        self.tag = tag
 
     def add_observation(self, observation, indx=None):
-        # Track all observations
-        if self.filtername is None:
+
+        if (self.filtername is None) and (self.tag is None):
+            # Track all observations
             self.feature += 1
-        else:
-            if observation['filter'][0] in self.filtername:
-                self.feature += 1
+        elif (self.filtername is not None) and (self.tag is None) and (observation['filter'][0] in self.filtername):
+            # Track all observations on a specified filter
+            self.feature += 1
+        elif (self.filtername is None) and (self.tag is not None) and (observation['tag'][0] in self.tag):
+            # Track all observations on a specified tag
+            self.feature += 1
+        elif ((self.filtername is None) and (self.tag is not None) and
+              # Track all observations on a specified filter on a specified tag
+              (observation['filter'][0] in self.filtername) and (observation['tag'][0] in self.tag)):
+            self.feature += 1
 
 
 class N_obs_survey(BaseSurveyFeature):
@@ -118,6 +127,27 @@ class N_obs_survey(BaseSurveyFeature):
                 self.feature += 1
 
 
+class N_obs_area(BaseSurveyFeature):
+    """Count the number of observations that happened on a specific region.
+    """
+    def __init__(self, tag_map=None):
+        """
+        Parameters
+        ----------
+        tag_map : np.ndarray (None)
+            A healpix map with a tag map. Only observations with tag equals to the region tag will be counted.
+        """
+        self.feature = 0
+        self.tag_map = tag_map
+
+    def add_observation(self, observation, indx=None):
+
+        if self.tag_map is not None:
+            tags = np.unique(self.tag_map[indx])
+            if observation['tag'] in tags:
+                self.feature += 1
+
+
 class Last_observation(BaseSurveyFeature):
     """When was the last observation
     """
@@ -131,6 +161,19 @@ class Last_observation(BaseSurveyFeature):
             if self.survey_name in observation['note']:
                 self.feature = observation
         else:
+            self.feature = observation
+
+
+class LastSequence_observation(BaseSurveyFeature):
+    """When was the last observation
+    """
+    def __init__(self, sequence_ids=''):
+        self.sequence_ids = sequence_ids  # The ids of all sequence observations...
+        # Start out with an empty observation
+        self.feature = utils.empty_observation()
+
+    def add_observation(self, observation, indx=None):
+        if observation['survey_id'] in self.sequence_ids:
             self.feature = observation
 
 
@@ -210,7 +253,9 @@ class Last_observed(BaseSurveyFeature):
         self.feature = np.zeros(hp.nside2npix(nside), dtype=float)
 
     def add_observation(self, observation, indx=None):
-        if observation['filter'][0] in self.filtername:
+        if self.filtername is None:
+            self.feature[indx] = observation['mjd']
+        elif observation['filter'][0] in self.filtername:
             self.feature[indx] = observation['mjd']
 
 
@@ -358,10 +403,46 @@ class M5Depth(BaseConditionsFeature):
         self.feature = ma.masked_values(self.feature, hp.UNSEEN)
 
 
+class SkyBrightness(BaseConditionsFeature):
+    """
+    Given current conditions, return the 5-sigma limiting depth for a filter.
+    """
+    def __init__(self, filtername='r', nside=default_nside):
+        if nside is None:
+            nside = utils.set_default_nside()
+
+        self.filtername = filtername
+        self.feature = None
+        self.nside = nside
+
+    def update_conditions(self, conditions):
+        """
+        Parameters
+        ----------
+        conditions : dict
+            Keys should include airmass, sky_brightness, seeing.
+        """
+        sb = np.empty(conditions['skybrightness'][self.filtername].size)
+        sb.fill(hp.UNSEEN)
+        sb_mask = np.zeros(sb.size, dtype=bool)
+        sb_mask[np.where(conditions['skybrightness'][self.filtername] == hp.UNSEEN)] = True
+        good = np.where(conditions['skybrightness'][self.filtername] != hp.UNSEEN)
+        sb[good] = conditions['skybrightness'][self.filtername][good]
+        self.feature = sb
+        self.feature[sb_mask] = hp.UNSEEN
+        self.feature = hp.ud_grade(self.feature, nside_out=self.nside)
+        self.feature = ma.masked_values(self.feature, hp.UNSEEN)
+
+
 class Current_filter(BaseConditionsFeature):
     def update_conditions(self, conditions):
         self.feature = conditions['filter']
 
+
+class HP2Fields(BaseConditionsFeature):
+    def update_conditions(self, conditions):
+        if 'hp2fields' in conditions:
+            self.feature = conditions['hp2fields']
 
 class Mounted_filters(BaseConditionsFeature):
     def update_conditions(self, conditions):
@@ -374,6 +455,15 @@ class Mounted_filters(BaseConditionsFeature):
 class Sun_moon_alts(BaseConditionsFeature):
     def update_conditions(self, conditions):
         self.feature = {'moonAlt': conditions['moonAlt'], 'sunAlt': conditions['sunAlt']}
+
+
+class Moon(BaseConditionsFeature):
+    def update_conditions(self, conditions):
+        self.feature = {'moonAlt': conditions['moonAlt'],
+                        'moonAz': conditions['moonAz'],
+                        'moonPhase': conditions['moonPhase'],
+                        'moonRA': conditions['moonRA'],
+                        'moonDec': conditions['moonDec']}
 
 
 class Current_mjd(BaseConditionsFeature):
@@ -415,7 +505,8 @@ class CurrentNightBoundaries(BaseConditionsFeature):
 
 class Current_pointing(BaseConditionsFeature):
     def update_conditions(self, conditions):
-        self.feature = {'RA': conditions['telRA'], 'dec': conditions['telDec']}
+        self.feature = {'RA': conditions['telRA'], 'dec': conditions['telDec'],
+                        'alt': conditions['telAlt'], 'az': conditions['telAz']}
 
 
 class Time_to_set(BaseConditionsFeature):

--- a/python/lsst/sims/featureScheduler/features.py
+++ b/python/lsst/sims/featureScheduler/features.py
@@ -177,6 +177,25 @@ class LastSequence_observation(BaseSurveyFeature):
             self.feature = observation
 
 
+class LastFilterChange(BaseSurveyFeature):
+    """When was the last observation
+    """
+    def __init__(self):
+        self.feature = {'mjd': 0.,
+                        'previous_filter': None,
+                        'current_filter': None}
+
+    def add_observation(self, observation, indx=None):
+        if self.feature['current_filter'] is None:
+            self.feature['mjd'] = observation['mjd'][0]
+            self.feature['previous_filter'] = None
+            self.feature['current_filter'] = observation['filter'][0]
+        elif observation['filter'][0] != self.feature['current_filter']:
+            self.feature['mjd'] = observation['mjd'][0]
+            self.feature['previous_filter'] = self.feature['current_filter']
+            self.feature['current_filter'] = observation['filter'][0]
+
+
 class N_observations(BaseSurveyFeature):
     """
     Track the number of observations that have been made accross the sky.
@@ -206,7 +225,7 @@ class N_observations(BaseSurveyFeature):
         indx : ints
             The indices of the healpixel map that have been observed by observation
         """
-        if observation['filter'][0] in self.filtername:
+        if self.filtername is None or observation['filter'][0] in self.filtername:
             self.feature[indx] += 1
 
         if self.mask_indx is not None:

--- a/python/lsst/sims/featureScheduler/surveys.py
+++ b/python/lsst/sims/featureScheduler/surveys.py
@@ -777,7 +777,7 @@ class Greedy_survey_fields(BaseSurvey):
     def add_observation(self, observation, **kwargs):
         # ugh, I think here I have to assume observation is an array and not a dict.
 
-        if self.ignore_obs not in observation['note']:
+        if self.ignore_obs not in str(observation['note']):
             for bf in self.basis_functions:
                 bf.add_observation(observation, **kwargs)
             for feature in self.extra_features:

--- a/python/lsst/sims/featureScheduler/utils.py
+++ b/python/lsst/sims/featureScheduler/utils.py
@@ -604,6 +604,7 @@ def generate_cloud_map(target_maps=None, filtername='r', wfd_cloud_max=0.7,
 
     return cloud_map
 
+
 def generate_sb_map(target_maps, filters, wfd_sb_limits=None,
                     scp_sb_limits=None, gp_sb_limits=None, nes_sb_limits=None):
     """

--- a/python/lsst/sims/featureScheduler/utils.py
+++ b/python/lsst/sims/featureScheduler/utils.py
@@ -604,6 +604,84 @@ def generate_cloud_map(target_maps=None, filtername='r', wfd_cloud_max=0.7,
 
     return cloud_map
 
+def generate_sb_map(target_maps, filters, wfd_sb_limits=None,
+                    scp_sb_limits=None, gp_sb_limits=None, nes_sb_limits=None):
+    """
+
+    Parameters
+    ----------
+    target_maps:
+    filters:
+    wfd_sb_limits:
+    scp_sb_limits:
+    gp_sb_limits:
+    nes_sb_limits:
+
+    Returns
+    -------
+
+    """
+
+    if wfd_sb_limits is None:
+        wfd_sb_limits = {'u': {'min': 21.30, 'max': 30.00},
+                         'g': {'min': 21.00, 'max': 30.00},
+                         'r': {'min': 20.25, 'max': 30.00},
+                         'i': {'min': 19.50, 'max': 30.00},
+                         'z': {'min': 17.00, 'max': 21.00},
+                         'y': {'min': 16.50, 'max': 21.00},
+                         }
+
+    if scp_sb_limits is None:
+        scp_sb_limits = {'u': {'min': 21.30, 'max': 30.00},
+                         'g': {'min': 21.00, 'max': 30.00},
+                         'r': {'min': 20.25, 'max': 30.00},
+                         'i': {'min': 19.50, 'max': 30.00},
+                         'z': {'min': 17.00, 'max': 21.00},
+                         'y': {'min': 16.50, 'max': 21.00},
+                         }
+
+    if gp_sb_limits is None:
+        gp_sb_limits = {'u': {'min': 21.30, 'max': 30.00},
+                        'g': {'min': 21.00, 'max': 30.00},
+                        'r': {'min': 20.25, 'max': 30.00},
+                        'i': {'min': 19.50, 'max': 30.00},
+                        'z': {'min': 17.00, 'max': 21.00},
+                        'y': {'min': 16.50, 'max': 21.00},
+                        }
+
+    if nes_sb_limits is None:
+        nes_sb_limits = {'u': {'min': 21.30, 'max': 30.00},
+                         'g': {'min': 21.00, 'max': 30.00},
+                         'r': {'min': 20.25, 'max': 30.00},
+                         'i': {'min': 19.50, 'max': 30.00},
+                         'z': {'min': 17.00, 'max': 21.00},
+                         'y': {'min': 16.50, 'max': 21.00},
+                         }
+
+    sb_map = {}
+    for filtername in filters:
+        sb_map_min = np.zeros_like(target_maps[filtername][0])
+        sb_map_max = np.zeros_like(target_maps[filtername][0])
+
+        wfd_cloud = np.where(target_maps[filtername][1] == 3)
+        scp_cloud = np.where(target_maps[filtername][1] == 2)
+        gp_cloud = np.where(target_maps[filtername][1] == 4)
+        nes_cloud = np.where(target_maps[filtername][1] == 1)
+
+        sb_map_min[wfd_cloud] = wfd_sb_limits[filtername]['min']
+        sb_map_min[scp_cloud] = scp_sb_limits[filtername]['min']
+        sb_map_min[gp_cloud] = gp_sb_limits[filtername]['min']
+        sb_map_min[nes_cloud] = nes_sb_limits[filtername]['min']
+
+        sb_map_max[wfd_cloud] = wfd_sb_limits[filtername]['max']
+        sb_map_max[scp_cloud] = scp_sb_limits[filtername]['max']
+        sb_map_max[gp_cloud] = gp_sb_limits[filtername]['max']
+        sb_map_max[nes_cloud] = nes_sb_limits[filtername]['max']
+        sb_map[filtername] = {'min': sb_map_min,
+                              'max': sb_map_max}
+
+    return sb_map
+
 
 def standard_goals(nside=None):
     """


### PR DESCRIPTION
Changes includes:

* basis_functions:
	- add Normalized_Target_map_basis_function: This bf provides normalized Target basis function to prevent the bf from increasing as observations is accumulated, which was causing the other bfs from basically be neglected.
	-  add Goal_Strict_filter_basis_function: In order to compensate from normalizing the Target map, this filter change basis function select the filter based on the number of observations and goals.
	-  add Agreesive_Slewtime_basis_function: This slewtime basis function adds an order to the equation, this way it is possible to select a higher order penalty for longer slews.
	-  add Moon_avoidance_basis_function: Implements a controllable moon exclusion zone.
	-  add Skybrightness_limit_basis_function: Implements a controllable sky brightness cuts.
	-  add HourAngle_bonus_basis_function: Implements an hour angle bonus, similar to the one used on the proposal based scheduler.
	-  add NorthSouth_scan_basis_function: This basis function favors slews in the North/South direction.
	-  add CableWrap_unwrap_basis_function: This basis function can be used to unwrap the cable wrap before the telescope is put into a corner. It activates once the telescope arrive at a certain absolute position, favoring slews in in unwrap direction. It then deactivates once a certain limit is achieved.

* core_scheduler:
	- add a logger to CoreScheduler .
	- add a flag to indicate whether an observation is part of a sequence or not.
	- add logic to check observations that are part of a sequence before proposing them.  In some cases, observations that are part of a sequence get observed when conditions are not met anymore after the sequence has started.

* features:
	-  Modify N_obs_count to also accept a tag for filtering.
	-  add LastSequence_observation: This feature stores the last sequence observation.
	-  add SkyBrightness: This feature stores the sky brightness conditions.
	-  add HP2Fields: A feature to map heal pixels to fields.
	-  add Moon: A feature to map information about the moon.
	-  add Current_pointing: Adds telescope altitude and azimuth to the current pointing information.

* surveys:
	- On BaseSurvey: add flags to identify Surveys that produce "sequence" of observations.
	- On Greedy_survey_fields: When checking for feasibility, call feasibility check on basis functions.
	- Create _update_conditions and update_conditions. The former only performs the update task and the later, adds some extra logic for nightly tasks.
	- On Deep_drilling_survey. Add checks for moon distance, set it as a sequence survey, add ability to shuffle filters around and add flag to avoid doing deep drilling surveys on the same night. The filter shuffling algorithms works by first setting the current filter as the first filter of the sequence. Then, it selects the filter with the lowest progress (given a certain goal) to end the sequence.
	- Add Pairs_different_filters_scripted: This is a pair survey designed to take pairs in different filters.

* utils:
	- Add generate_sb_map: A method to generate default sky brightness limits maps.

* driver:
	- Add some tweaks to enable integration with sims_ocs running on notebooks.
	- When filling the telemetry stream, passes absolute telescope position.
	- Call observatory model approximate slew with dome crawling (when dome crawling is on).
	- Adds information about the moon to the telemetry stream.

* driver.config:
	- update default fbs configuration used by the driver.

* examples:
	- Adds two example notebooks on how to run the fbs using sims_ocs, instead of simrunner. The simple script runs fbs using the default configuration while a complex notebook shows how to setup and run using a custom configuration done inside the notebook.