### PR TITLE
U/yoachim/ddf scheduled

### DIFF
--- a/python/lsst/sims/featureScheduler/basis_functions/feasibility_funcs.py
+++ b/python/lsst/sims/featureScheduler/basis_functions/feasibility_funcs.py
@@ -12,7 +12,7 @@ __all__ = ['Filter_loaded_basis_function', 'Time_to_twilight_basis_function',
            'Rising_more_basis_function', 'Soft_delay_basis_function',
            'Look_ahead_ddf_basis_function', 'Sun_alt_limit_basis_function',
            'Time_in_twilight_basis_function', 'Night_modulo_basis_function',
-           'End_of_evening_basis_function']
+           'End_of_evening_basis_function', 'Time_to_scheduled_basis_function']
 
 
 class Filter_loaded_basis_function(Base_basis_function):
@@ -112,6 +112,28 @@ class Time_to_twilight_basis_function(Base_basis_function):
 
     def check_feasibility(self, conditions):
         available_time = getattr(conditions, 'sun_n' + self.alt_limit + '_rising') - conditions.mjd
+        result = available_time > self.time_needed
+        return result
+
+
+class Time_to_scheduled_basis_function(Base_basis_function):
+    """Make sure there is enough time before next scheduled observation. Useful
+    if you want to check before starting a long sequence of observations.
+
+    Parameters
+    ----------
+    time_needed : float (30.)
+        The time needed to run a survey (mintues).
+    """
+    def __init__(self, time_needed=30.):
+        super(Time_to_scheduled_basis_function, self).__init__()
+        self.time_needed = time_needed/60./24.  # To days
+
+    def check_feasibility(self, conditions):
+        if len(conditions.scheduled_observations) == 0:
+            return True
+
+        available_time = np.min(conditions.scheduled_observations) - conditions.mjd
         result = available_time > self.time_needed
         return result
 

--- a/python/lsst/sims/featureScheduler/detailers/detailer.py
+++ b/python/lsst/sims/featureScheduler/detailers/detailer.py
@@ -1,6 +1,6 @@
-from lsst.sims.utils import _raDec2Hpid, _approx_RaDec2AltAz, _angularSeparation
+from lsst.sims.utils import _raDec2Hpid, _approx_RaDec2AltAz, _angularSeparation, _approx_altaz2pa
 import numpy as np
-from lsst.sims.featureScheduler.utils import approx_altaz2pa, int_rounded
+from lsst.sims.featureScheduler.utils import int_rounded
 import copy
 
 __all__ = ["Base_detailer", "Zero_rot_detailer", "Comcam_90rot_detailer", "Close_alt_detailer",
@@ -66,7 +66,7 @@ class Zero_rot_detailer(Base_detailer):
         for obs in observation_list:
             alt, az = _approx_RaDec2AltAz(obs['RA'], obs['dec'], conditions.site.latitude_rad,
                                           conditions.site.longitude_rad, conditions.mjd)
-            obs_pa = approx_altaz2pa(alt, az, conditions.site.latitude_rad)
+            obs_pa = _approx_altaz2pa(alt, az, conditions.site.latitude_rad)
             obs['rotSkyPos'] = obs_pa
 
         return observation_list
@@ -100,7 +100,7 @@ class Comcam_90rot_detailer(Base_detailer):
         obs_array =np.concatenate(observation_list)
         alt, az = _approx_RaDec2AltAz(obs_array['RA'], obs_array['dec'], conditions.site.latitude_rad,
                                       conditions.site.longitude_rad, conditions.mjd)
-        parallactic_angle = approx_altaz2pa(alt, az, conditions.site.latitude_rad)
+        parallactic_angle = _approx_altaz2pa(alt, az, conditions.site.latitude_rad)
         # If we set rotSkyPos to parallactic angle, rotTelPos will be zero. So, find the
         # favored rotSkyPos that is closest to PA to keep rotTelPos as close as possible to zero.
         ang_diff = np.abs(parallactic_angle - favored_rotSkyPos)
@@ -211,10 +211,3 @@ class Twilight_triple_detailer(Base_detailer):
             out_obs.extend(copy.deepcopy(observation_list))
 
         return out_obs
-
-
-
-
-
-
-

--- a/python/lsst/sims/featureScheduler/detailers/dither_detailer.py
+++ b/python/lsst/sims/featureScheduler/detailers/dither_detailer.py
@@ -114,20 +114,21 @@ class Camera_rot_detailer(Base_detailer):
         else:
             offsets = np.random.random(n_offsets) * self.range + self.min_rot
 
-        offsets = offsets #% (2.*np.pi)
+        offsets = offsets % (2.*np.pi)
 
         return offsets
 
     def __call__(self, observation_list, conditions):
 
-        # Generate offsets in RA and Dec
+        # Generate offsets in camamera rotator
         offsets = self._generate_offsets(len(observation_list), conditions.night)
 
         for i, obs in enumerate(observation_list):
             alt, az = _approx_RaDec2AltAz(obs['RA'], obs['dec'], conditions.site.latitude_rad,
                                           conditions.site.longitude_rad, conditions.mjd)
             obs_pa = approx_altaz2pa(alt, az, conditions.site.latitude_rad)
-            #obs['rotSkyPos'] = (obs_pa + offsets[i]) % (2.*np.pi)
+            obs['rotSkyPos'] = (offsets[i] - obs_pa) % (2.*np.pi)
             obs['rotTelPos'] = offsets[i]
+            
 
         return observation_list

--- a/python/lsst/sims/featureScheduler/detailers/dither_detailer.py
+++ b/python/lsst/sims/featureScheduler/detailers/dither_detailer.py
@@ -114,7 +114,7 @@ class Camera_rot_detailer(Base_detailer):
         else:
             offsets = np.random.random(n_offsets) * self.range + self.min_rot
 
-        offsets = offsets % (2.*np.pi)
+        offsets = offsets #% (2.*np.pi)
 
         return offsets
 
@@ -127,6 +127,7 @@ class Camera_rot_detailer(Base_detailer):
             alt, az = _approx_RaDec2AltAz(obs['RA'], obs['dec'], conditions.site.latitude_rad,
                                           conditions.site.longitude_rad, conditions.mjd)
             obs_pa = approx_altaz2pa(alt, az, conditions.site.latitude_rad)
-            obs['rotSkyPos'] = (obs_pa + offsets[i]) % (2.*np.pi)
+            #obs['rotSkyPos'] = (obs_pa + offsets[i]) % (2.*np.pi)
+            obs['rotTelPos'] = offsets[i]
 
         return observation_list

--- a/python/lsst/sims/featureScheduler/detailers/dither_detailer.py
+++ b/python/lsst/sims/featureScheduler/detailers/dither_detailer.py
@@ -1,7 +1,6 @@
 import numpy as np
 from lsst.sims.featureScheduler.detailers import Base_detailer
-from lsst.sims.utils import _approx_RaDec2AltAz
-from lsst.sims.featureScheduler.utils import approx_altaz2pa
+from lsst.sims.utils import _approx_RaDec2AltAz, _approx_altaz2pa
 
 
 __all__ = ["Dither_detailer", "Camera_rot_detailer"]
@@ -126,9 +125,8 @@ class Camera_rot_detailer(Base_detailer):
         for i, obs in enumerate(observation_list):
             alt, az = _approx_RaDec2AltAz(obs['RA'], obs['dec'], conditions.site.latitude_rad,
                                           conditions.site.longitude_rad, conditions.mjd)
-            obs_pa = approx_altaz2pa(alt, az, conditions.site.latitude_rad)
+            obs_pa = _approx_altaz2pa(alt, az, conditions.site.latitude_rad)
             obs['rotSkyPos'] = (offsets[i] - obs_pa) % (2.*np.pi)
             obs['rotTelPos'] = offsets[i]
-            
 
         return observation_list

--- a/python/lsst/sims/featureScheduler/features/conditions.py
+++ b/python/lsst/sims/featureScheduler/features/conditions.py
@@ -144,7 +144,7 @@ class Conditions(object):
             the 5-sigma limiting depth healpix maps, keyed by filtername (mags). Will be recalculated
             if the skybrightness, seeing, or airmass are updated.
         HA : np.array
-            Healpix map of the hour angle of each healpixel (radians).
+            Healpix map of the hour angle of each healpixel (radians). Runs from 0 to 2pi.
         az_to_sun : np.array
             Healpix map of the azimuthal distance to the sun for each healpixel (radians)
 

--- a/python/lsst/sims/featureScheduler/features/conditions.py
+++ b/python/lsst/sims/featureScheduler/features/conditions.py
@@ -1,7 +1,7 @@
 import numpy as np
-from lsst.sims.utils import _approx_RaDec2AltAz, Site, _hpid2RaDec, m5_flat_sed
+from lsst.sims.utils import _approx_RaDec2AltAz, Site, _hpid2RaDec, m5_flat_sed, _approx_altaz2pa
 import healpy as hp
-from lsst.sims.featureScheduler.utils import set_default_nside, match_hp_resolution, approx_altaz2pa, season_calc
+from lsst.sims.featureScheduler.utils import set_default_nside, match_hp_resolution, season_calc
 
 __all__ = ['Conditions']
 
@@ -299,7 +299,7 @@ class Conditions(object):
         return self._pa
 
     def calc_pa(self):
-        self._pa = approx_altaz2pa(self.alt, self.az, self.site.latitude_rad)
+        self._pa = _approx_altaz2pa(self.alt, self.az, self.site.latitude_rad)
 
     @property
     def alt(self):

--- a/python/lsst/sims/featureScheduler/features/conditions.py
+++ b/python/lsst/sims/featureScheduler/features/conditions.py
@@ -46,7 +46,7 @@ class Conditions(object):
         dec : np.array
             A healpix array with the Dec of each healpixel center (radians). Automatically generated.
 
-        Attributes (to be set by user/telemetry stream)
+        Attributes (to be set by user/telemetry stream/scheduler)
         -------------------------------------------
         mjd : float
             Modified Julian Date (days).
@@ -124,6 +124,8 @@ class Conditions(object):
             targetoO objects.
         planet_positions : dict
             Dictionary of planet name and coordinate e.g., 'venus_RA', 'mars_dec'
+        scheduled_observations : np.array
+            A list of MJD times when there are scheduled observations. Defaults to empty array.
 
         Attributes (calculated on demand and cached)
         ------------------------------------------
@@ -186,6 +188,9 @@ class Conditions(object):
         self._FWHMeff = {}
         self._M5Depth = None
         self._airmass = None
+
+        # Upcomming scheduled observations
+        self.scheduled_observations = np.array([], dtype=float)
 
         # Attribute to hold the current observing queue
         self.queue = None

--- a/python/lsst/sims/featureScheduler/modelObservatory/__init__.py
+++ b/python/lsst/sims/featureScheduler/modelObservatory/__init__.py
@@ -1,1 +1,2 @@
 from .model_observatory import *
+from .kinem_model import *

--- a/python/lsst/sims/featureScheduler/modelObservatory/__init__.py
+++ b/python/lsst/sims/featureScheduler/modelObservatory/__init__.py
@@ -1,2 +1,2 @@
-from .model_observatory import *
 from .kinem_model import *
+from .model_observatory import *

--- a/python/lsst/sims/featureScheduler/modelObservatory/kinem_model.py
+++ b/python/lsst/sims/featureScheduler/modelObservatory/kinem_model.py
@@ -3,17 +3,10 @@ from astropy.coordinates import EarthLocation
 from lsst.sims.utils import Site, calcLmstLast
 import healpy as hp
 import matplotlib.pylab as plt
+from lsst.sims.featureScheduler.utils import approx_altaz2pa
 
 __all__ = ["Kinem_model"]
 TwoPi = 2.*np.pi
-
-
-def parallactic_angle(ha_rad, lat_rad, dec_rad):
-    """Return the parallactic angle
-    """
-    # XXX--double check I did this right.
-    result = np.arctan2(np.sin(ha_rad), np.cos(dec_rad)*np.tan(lat_rad)-np.sin(dec_rad)*np.cos(ha_rad))
-    return result
 
 
 # Snagged from lsst.sims.utils for now to add in parallactic angle. Might want to update back there
@@ -66,7 +59,7 @@ def _approx_RaDec2AltAz(ra, dec, lat, lon, mjd, lmst=None, return_pa=True):
         signflip = np.where(np.sin(ha) > 0)
         az[signflip] = 2.*np.pi-az[signflip]
     if return_pa:
-        pa = parallactic_angle(ha, lat, dec)
+        pa = approx_altaz2pa(alt, az, lat)
         return alt, az, pa
     return alt, az
 

--- a/python/lsst/sims/featureScheduler/modelObservatory/kinem_model.py
+++ b/python/lsst/sims/featureScheduler/modelObservatory/kinem_model.py
@@ -47,7 +47,6 @@ def smallest_signed_angle(a1, a2):
     result = b+0
     alb = np.where(a < b)[0]
     result[alb] = -1.*a[alb]
-    #return -a if a < b else b
     return result
 
 
@@ -239,10 +238,9 @@ class Kinem_model(object):
         """Calculates ``slew'' time to a series of alt/az/filter positions from the current
         position (stored internally).
         Assumptions (currently):
-            assumes  we never max out cable wrap-around!--For now--XXX to update
             Assumes we have been tracking on ra,dec,rotSkyPos position.
             Ignores the motion of the sky while we are slewing (this approx should probably average out over time).
-            No checks for if we have tracked beyond limits. May want to put telescope in park if there is a large gap.
+            No checks for if we have tracked beyond limits. Assumes folks put telescope in park if there's a long gap.
             Assumes the camera rotator never needs to (or can't) do a slew over 180 degrees.
 
         Calculates the ``slew'' time necessary to get from current state
@@ -289,7 +287,7 @@ class Kinem_model(object):
         Returns
         -------
         np.ndarray
-            The number of seconds between the two specified exposures.
+            The number of seconds between the two specified exposures. Will be np.nan or np.inf if slew is not possible.
         """
         if filtername not in self.mounted_filters:
             return np.nan

--- a/python/lsst/sims/featureScheduler/modelObservatory/kinem_model.py
+++ b/python/lsst/sims/featureScheduler/modelObservatory/kinem_model.py
@@ -1,5 +1,4 @@
 import numpy as np
-from astropy.coordinates import EarthLocation
 from lsst.sims.utils import Site, calcLmstLast, _approx_altAz2RaDec, _approx_altaz2pa, _approx_RaDec2AltAz
 import healpy as hp
 import matplotlib.pylab as plt
@@ -15,7 +14,7 @@ class radec2altazpa(object):
         self.location = location
 
     def __call__(self, ra, dec, mjd):
-        alt, az, pa = _approx_RaDec2AltAz(ra, dec, self.location.lat.rad, self.location.lon.rad, mjd,
+        alt, az, pa = _approx_RaDec2AltAz(ra, dec, self.location.lat_rad, self.location.lon_rad, mjd,
                                           return_pa=True)
         return alt, az, pa
 
@@ -73,9 +72,9 @@ class Kinem_model(object):
         self.park_az_rad = np.radians(park_az)
         self.current_filter = start_filter
         if location is None:
-            self.site = Site('LSST')
-            self.location = EarthLocation(lat=self.site.latitude, lon=self.site.longitude,
-                                          height=self.site.height)
+            self.location = Site('LSST')
+            self.location.lat_rad = np.radians(self.location.latitude)
+            self.location.lon_rad = np.radians(self.location.longitude)
         # Our RA,Dec to Alt,Az converter
         self.radec2altaz = radec2altazpa(self.location)
 
@@ -303,9 +302,9 @@ class Kinem_model(object):
         if alt_rad is None:
             alt_rad, az_rad, pa = self.radec2altaz(ra_rad, dec_rad, mjd)
         else:
-            pa = _approx_altaz2pa(alt_rad, az_rad, self.location.lat.rad)
-            ra_rad, dec_rad = _approx_altAz2RaDec(alt_rad, az_rad, self.location.lat.rad,
-                                                  self.location.lon.rad, mjd)
+            pa = _approx_altaz2pa(alt_rad, az_rad, self.location.lat_rad)
+            ra_rad, dec_rad = _approx_altAz2RaDec(alt_rad, az_rad, self.location.lat_rad,
+                                                  self.location.lon_rad, mjd)
 
         if starting_alt_rad is None:
             if self.parked:

--- a/python/lsst/sims/featureScheduler/modelObservatory/kinem_model.py
+++ b/python/lsst/sims/featureScheduler/modelObservatory/kinem_model.py
@@ -1,0 +1,328 @@
+import numpy as np
+from astropy.coordinates import SkyCoord, EarthLocation
+from astropy import coordinates as coordinates
+from astropy.time import Time
+from astropy import units as u
+from lsst.sims.utils import Site
+
+
+
+class radec2altaz(object):
+    def __init__(self, location):
+        self.location = location
+
+    def __call__(self, ra, dec, mjd, coords=None):
+        aa_frame = coordinates.AltAz(obstime=Time(mjd, format='mjd'), location=self.location)
+        if coords is None:
+            coords = SkyCoord(ra*u.rad, dec*u.rad)
+        aa_coords = coords.transform_to(aa_frame)
+        return aa_coords.alt.rad, aa_coords.az.rad
+
+
+TwoPi = 2.*np.pi
+def smallest_signed_angle(a1, a2):
+    """Assume angles between 0 and 2 pi
+    via https://stackoverflow.com/questions/1878907/the-smallest-difference-between-2-angles"""
+    a = (a1 - a2) % TwoPi
+    b = (a2 - a1) % TwoPi
+    return -a if a < b else b
+
+
+class Kinem_model(object):
+    """
+    A Kinematic model of the telescope.
+
+    Parameters
+    ----------
+    location : astropy.coordinates.EarthLocation object
+        The location of the telescope. If None, defaults to lsst.sims.utils.Site info
+    park_alt : float (86.5)
+        The altitude the telescope gets parked at (degrees)
+    """
+    def __init__(self, location=None, park_alt=86.5, park_filter='r'):
+        self.park_alt_rad = np.radians(park_alt)
+        self.park_filter = park_filter
+        if location is None:
+            self.site = Site('LSST')
+            self.location = EarthLocation(lat=self.site.latitude, lon=self.site.longitude,
+                                          height=self.site.height)
+        # Our RA,Dec to Alt,Az converter
+        self.radec2altaz = radec2altaz(self.location)
+
+        self.setup_camera()
+        self.setup_dome()
+        self.setup_telescope()
+        self.setup_optics()
+
+        # Park the telescope
+        self.park()
+
+    def setup_camera(self, readtime=2., shuttertime=1., filter_changetime=120., fov=3.5,
+                     rotator_min=-90, rotator_max=90, maxspeed=3.5, accel=1.0, decel=1.0):
+        """
+        Parameters
+        ----------
+        readtime : float (2)
+            The readout time of the CCDs (seconds)
+        shuttertime : float (1.)
+            The time it takes the shutter to go from closed to fully open (seconds)
+        filter_changetime : float (120)
+            The time it takes to change filters (seconds)
+        fov : float (3.5)
+            The camera field of view (degrees)
+        rotator_min : float (-90)
+            The minimum angle the camera rotator can move to (degrees)
+        maxspeed : float (3.5)
+            The maximum speed of the rotator (degrees/s)
+        accel : float (1.0)
+            The acceleration of the rotator (degrees/s^2)
+        """
+        self.readtime = readtime
+        self.shuttertime = shuttertime
+        self.filter_changetime = filter_changetime
+        self.camera_fov = np.radians(fov)
+
+        self.telrot_minpos_rad = np.radians(rotator_min)
+        self.telrot_maxpos_rad = np.radians(rotator_max)
+        self.telrot_maxspeed_rad = np.radians(maxspeed)
+        self.telrot_accel_rad = np.radians(accel)
+        self.telrot_decel_rad = np.radians(decel)
+
+    def setup_dome(self, altitude_maxspeed=1.75, altitude_accel=0.875, altitude_decel=0.875,
+                   altitude_freerange=0., azimuth_maxspeed=1.5, azimuth_accel=0.75,
+                   azimuth_decel=0.75, azimuth_freerange=4.0, settle_time=1.0):
+        """input in degrees, degees/second, degrees/second**2, and seconds.
+        Freerange is the range in which there is zero delay.
+        """
+        self.domalt_maxspeed_rad = np.radians(altitude_maxspeed)
+        self.domalt_accel_rad = np.radians(altitude_accel)
+        self.domalt_decel_rad = np.radians(altitude_decel)
+        self.domalt_free_range = np.radians(altitude_freerange)
+        self.domaz_maxspeed_rad = np.radians(azimuth_maxspeed)
+        self.domaz_accel_rad = np.radians(azimuth_accel)
+        self.domaz_decel_rad = np.radians(azimuth_decel)
+        self.domaz_free_range = np.radians(azimuth_freerange)
+        self.domaz_settletime = settle_time
+
+    def setup_telescope(self, altitude_minpos=20.0, altitude_maxpos=86.5,
+                        azimuth_minpos=-270.0, azimuth_maxpos=270.0, altitude_maxspeed=3.5,
+                        altitude_accel=3.5, altitude_decel=3.5, azimuth_maxspeed=7.0,
+                        azimuth_accel=7.0, azimuth_decel=7.0, settle_time=3.0):
+        """input in degrees, degees/second, degrees/second**2, and seconds.
+        """
+        self.telalt_minpos_rad = np.radians(altitude_minpos)
+        self.telalt_maxpos_rad = np.radians(altitude_maxpos)
+        self.telaz_minpos_rad = np.radians(azimuth_minpos)
+        self.telaz_maxpos_rad = np.radians(azimuth_maxpos)
+        self.telalt_maxspeed_rad = np.radians(altitude_maxspeed)
+        self.telalt_accel_rad = np.radians(altitude_accel)
+        self.telalt_decel_rad = np.radians(altitude_decel)
+        self.telaz_maxspeed_rad = np.radians(azimuth_maxspeed)
+        self.telaz_accel_rad = np.radians(azimuth_accel)
+        self.telaz_decel_rad = np.radians(azimuth_decel)
+        self.mount_settletime = settle_time
+
+    def setup_optics(self, ol_slope=1.0/3.5, cl_delay=[0.0, 36.], cl_altlimit=[0.0, 9.0, 90.0]):
+        """
+        Parameters
+        ----------
+        ol_slope : float
+            seconds/degree in altitude slew.
+        cl_delay : list ([0.0, 36])
+            The delays for closed optics loops (seconds)
+        cl_altlimit : list ([0.0, 9.0, 90.0])
+            The altitude limits (degrees) for performing closed optice loops. Should be one element longer than cl_delay.
+        """
+
+        self.optics_ol_slope = ol_slope/np.radians(1.)  # ah, 1./np.radians(1)=np.pi/180
+        self.optics_cl_delay = cl_delay
+        self.optics_cl_altlimit = np.radians(cl_altlimit)
+
+    def park(self):
+        # I'm going to ignore that the old model had the dome altitude at 90.
+        self.current_filter = self.park_filter
+        self.parked = True
+        self.current_coords = None
+        self.rotSkyPos = 0.
+        self.cumulative_azimuth_rad = 0
+        self.cumulative_camera_rad = 0
+        # Need to keep tabs on these because we could track a bit
+        # So, when we want to compute the cumulative, use these values, not the
+        # angles computed from converting self.current_coords to alt,az.
+        self.last_az_rad = 0
+        self.last_rot_tel_pos_rad = 0
+
+    def _uamSlewTime(self, distance, vmax, accel):
+        """Compute slew time delay assuming uniform acceleration (for any component).
+        If you accelerate uniformly to vmax, then slow down uniformly to zero, distance traveled is
+        d  = vmax**2 / accel
+        To travel distance d while accelerating/decelerating at rate a, time required is t = 2 * sqrt(d / a)
+        If hit vmax, then time to acceleration to/from vmax is 2*vmax/a and distance in those
+        steps is vmax**2/a. The remaining distance is (d - vmax^2/a) and time needed is (d - vmax^2/a)/vmax
+
+        This method accepts arrays of distance, and assumes acceleration == deceleration.
+
+        Parameters
+        ----------
+        distance : numpy.ndarray
+            Distances to travel. Must be positive value.
+        vmax : float
+            Max velocity
+        accel : float
+            Acceleration (and deceleration)
+
+        Returns
+        -------
+        numpy.ndarray
+        """
+        dm = vmax**2 / accel
+        slewTime = np.where(distance < dm, 2 * np.sqrt(distance / accel),
+                            2 * vmax / accel + (distance - dm) / vmax)
+        return slewTime
+
+    def slew_times(self, ra_rad, dec_rad, mjd, rotSkyPos=None, rotTelPos=None, filtername='r',
+                   lax_dome=True):
+        """Calculates ``slew'' time to a series of alt/az/filter positions.
+        Assumptions (currently):
+            assumes rotator is not moved (no rotator included)
+            assumes  we never max out cable wrap-around!
+
+        Calculates the ``slew'' time necessary to get from current state
+        to alt2/az2/filter2. The time returned is actually the time between
+        the end of an exposure at current location and the beginning of an exposure
+        at alt2/az2, since it includes readout time in the ``slew'' time.
+
+        Parameters
+        ----------
+        alt_rad : np.ndarray
+            The altitude of the destination pointing in RADIANS.
+        az_rad : np.ndarray
+            The azimuth of the destination pointing in RADIANS.
+        goal_filter : np.ndarray
+            The filter to be used in the destination observation.
+        lax_dome : boolean, default False
+            If True, allow the dome to creep, model a dome slit, and don't
+            require the dome to settle in azimuth. If False, adhere to the way
+            SOCS calculates slew times (as of June 21 2017).
+
+        Returns
+        -------
+        np.ndarray
+            The number of seconds between the two specified exposures.
+        """
+        alt_rad, az_rad = self.radec2altaz(ra_rad, dec_rad, mjd)
+        current_alt_rad, current_az_rad = self.radec2altaz(0, 0, mjd, coords=self.current_coords)
+
+        deltaAlt = np.abs(alt_rad - current_alt_rad)
+        deltaAz = np.abs(az_rad - current_az_rad)
+        deltaAz = np.minimum(deltaAz, np.abs(deltaAz - 2 * np.pi))
+
+        # Calculate how long the telescope will take to slew to this position.
+        telAltSlewTime = self._uamSlewTime(deltaAlt, self.telalt_maxspeed_rad,
+                                           self.telalt_accel_rad)
+        telAzSlewTime = self._uamSlewTime(deltaAz, self.telaz_maxspeed_rad,
+                                          self.telaz_accel_rad)
+        totTelTime = np.maximum(telAltSlewTime, telAzSlewTime)
+        # Time for open loop optics correction
+        olTime = deltaAlt / self.optics_ol_slope
+        totTelTime += olTime
+        # Add time for telescope settle.
+        # XXX--note, this means we're going to have a settle time even for very small slews (like even a dither)
+        settleAndOL = np.where(totTelTime > 0)
+        totTelTime[settleAndOL] += np.maximum(0, self.mount_settletime - olTime[settleAndOL])
+        # And readout puts a floor on tel time
+        totTelTime = np.maximum(self.readtime, totTelTime)
+
+        # now compute dome slew time
+        if lax_dome:
+            # model dome creep, dome slit, and no azimuth settle
+            # if we can fit both exposures in the dome slit, do so
+            sameDome = np.where(deltaAlt ** 2 + deltaAz ** 2 < self.camera_fov ** 2)
+
+            # else, we take the minimum time from two options:
+            # 1. assume we line up alt in the center of the dome slit so we
+            #    minimize distance we have to travel in azimuth.
+            # 2. line up az in the center of the slit
+            # also assume:
+            # * that we start out going maxspeed for both alt and az
+            # * that we only just barely have to get the new field in the
+            #   dome slit in one direction, but that we have to center the
+            #   field in the other (which depends which of the two options used)
+            # * that we don't have to slow down until after the shutter
+            #   starts opening
+            domDeltaAlt = deltaAlt
+            # on each side, we can start out with the dome shifted away from
+            # the center of the field by an amount domSlitRadius - fovRadius
+            domSlitDiam = self.camera_fov / 2.0
+            domDeltaAz = deltaAz - 2 * (domSlitDiam / 2 - self.camera_fov / 2)
+            domAltSlewTime = domDeltaAlt / self.domalt_maxspeed_rad
+            domAzSlewTime = domDeltaAz / self.domaz_maxspeed_rad
+            totDomTime1 = np.maximum(domAltSlewTime, domAzSlewTime)
+
+            domDeltaAlt = deltaAlt - 2 * (domSlitDiam / 2 - self.camera_fov / 2)
+            domDeltaAz = deltaAz
+            domAltSlewTime = domDeltaAlt / self.domalt_maxspeed_rad
+            domAzSlewTime = domDeltaAz / self.domaz_maxspeed_rad
+            totDomTime2 = np.maximum(domAltSlewTime, domAzSlewTime)
+
+            totDomTime = np.minimum(totDomTime1, totDomTime2)
+            totDomTime[sameDome] = 0
+
+        else:
+            # the above models a dome slit and dome creep. However, it appears that
+            # SOCS requires the dome to slew exactly to each field and settle in az
+            domAltSlewTime = self._uamSlewTime(deltaAlt, self.domalt_maxspeed_rad,
+                                               self.domalt_accel_rad)
+            domAzSlewTime = self._uamSlewTime(deltaAz, self.domaz_maxspeed_rad,
+                                              self.domaz_accel_rad)
+            # Dome takes 1 second to settle in az
+            domAzSlewTime = np.where(domAzSlewTime > 0,
+                                     domAzSlewTime + self.domaz_settletime,
+                                     domAzSlewTime)
+            totDomTime = np.maximum(domAltSlewTime, domAzSlewTime)
+        # Find the max of the above for slew time.
+        slewTime = np.maximum(totTelTime, totDomTime)
+        # include filter change time if necessary
+        filterChange = np.where(filtername != self.current_filter)
+        slewTime[filterChange] = np.maximum(slewTime[filterChange],
+                                            self.filter_changetime)
+        # Add closed loop optics correction
+        # Find the limit where we must add the delay
+        cl_limit = self.optics_cl_altlimit[1]
+        cl_delay = self.optics_cl_delay[1]
+        closeLoop = np.where(deltaAlt >= cl_limit)
+        slewTime[closeLoop] += cl_delay
+
+        # Mask min/max altitude limits so slewtime = np.nan
+        outsideLimits = np.where((alt_rad > self.telalt_maxpos_rad) |
+                                 (alt_rad < self.telalt_minpos_rad))
+        slewTime[outsideLimits] = np.nan
+        return slewTime
+
+    def single_slew_time(self, ra_target_rad, dec_target_rad, rotSkyPos, mjd, rotTelPos=None,
+                         include_read=True, update=True):
+        """Compute the slewtime between current position and a new pointing.
+        """
+
+        # Compute the time it takes the dome and telescope to slew to new position
+        dome_tel_time = self.slew_times(mjd, ra_target_rad, dec_target_rad)
+
+        # Compute the rotation time as well
+        if rotTelPos is None:
+            # Compute the taget rotTelPos needed from rotSkyPos
+            pass
+
+        # How long does it take to move the rotator
+        rotator_time = self._uamSlewTime(deltaRotation, self.telrot_maxspeed_rad, self.telrot_accel_rad)
+
+        slewtime = np.maximum(dome_tel_time, rotator_time)
+
+        # Update the current state of the telescope
+        if update:
+            self.current_coords = SkyCoord(ra_target_rad*u.rad, dec_target_rad*u.rad)
+            self.park = False
+            self.rotSkyPos = rotSkyPos
+            # Track the cumulative azimuth and camera rotation
+
+        return slewtime
+

--- a/python/lsst/sims/featureScheduler/modelObservatory/kinem_model.py
+++ b/python/lsst/sims/featureScheduler/modelObservatory/kinem_model.py
@@ -92,10 +92,12 @@ def _getRotTelPos(paRad, rotSkyRad):
 
 
 def smallest_signed_angle(a1, a2):
-    """Assume angles between 0 and 2 pi
+    """
     via https://stackoverflow.com/questions/1878907/the-smallest-difference-between-2-angles"""
-    a = (a1 - a2) % TwoPi
-    b = (a2 - a1) % TwoPi
+    x = a1 % TwoPi
+    y = a2 % TwoPi
+    a = (x - y) % TwoPi
+    b = (y - x) % TwoPi
     return -a if a < b else b
 
 
@@ -225,10 +227,10 @@ class Kinem_model(object):
         # I'm going to ignore that the old model had the dome altitude at 90.
         self.current_filter = self.park_filter
         self.parked = True
+        # XXX--change to current_RA_rad, current_rotSkyPos.
         self.current_coords = [None, None]
         self.rotSkyPos = None
         self.cumulative_azimuth_rad = 0
-        self.cumulative_camera_rad = 0
         # Need to keep tabs on these because we could track a bit
         # So, when we want to compute the cumulative, use these values, not the
         # angles computed from converting self.current_coords to alt,az.
@@ -430,13 +432,12 @@ class Kinem_model(object):
             self.current_coords = [ra_rad, dec_rad]
             self.rotSkyPos = rotSkyPos
             self.parked = False
-            # Track the cumulative azimuth and camera rotation
             self.last_rot_tel_pos_rad = rotTelPos
             self.last_az_rad = az_rad
             self.last_alt_rad = alt_rad
             self.last_pa_rad = pa
+            # Track the cumulative azimuth
             self.cumulative_azimuth_rad += smallest_signed_angle(self.cumulative_azimuth_rad, az_rad)
-            self.cumulative_camera_rad += deltaRotation
             self.current_filter = filtername
             self.last_mjd = mjd
 

--- a/python/lsst/sims/featureScheduler/modelObservatory/model_observatory.py
+++ b/python/lsst/sims/featureScheduler/modelObservatory/model_observatory.py
@@ -433,6 +433,7 @@ class Model_observatory(object):
         if ~np.all(np.isfinite(slewtime)):
             result = None
             new_night = False
+            import pdb ; pdb.set_trace()
             raise ValueError("Slew failed")
 
         # Check if the mjd after slewtime and visitime is fine:

--- a/python/lsst/sims/featureScheduler/modelObservatory/model_observatory.py
+++ b/python/lsst/sims/featureScheduler/modelObservatory/model_observatory.py
@@ -226,7 +226,7 @@ class Model_observatory(object):
         slewtimes.fill(np.nan)
         slewtimes[good] = self.observatory.slew_times(0., 0., self.mjd, alt_rad=alts[good], az_rad=azs[good],
                                                       filtername=self.observatory.current_filter,
-                                                      lax_dome=self.lax_dome, update=False)
+                                                      lax_dome=self.lax_dome, update_tracking=False)
         self.conditions.slewtime = slewtimes
 
         # Let's get the sun and moon

--- a/python/lsst/sims/featureScheduler/modelObservatory/model_observatory.py
+++ b/python/lsst/sims/featureScheduler/modelObservatory/model_observatory.py
@@ -689,7 +689,14 @@ class Model_observatory(object):
 
         # Check if the mjd after slewtime and visitime is fine:
         observation_worked, new_mjd = self.check_mjd(self.mjd + (slewtime + visittime)/24./3600.)
-        if observation_worked:
+
+        # See if the observatory ended up in a failed state (e.g., slewed out of bounds)
+        if self.observatory.current_state.fail_state:
+            result = None
+            new_night = False
+            # Let's move the time forward as a modest penalty.
+            self.mjd = self.mjd + slewtime
+        elif observation_worked:
             observation['visittime'] = visittime
             observation['slewtime'] = slewtime
             observation['slewdist'] = _angularSeparation(start_ra, start_dec,

--- a/python/lsst/sims/featureScheduler/modelObservatory/model_observatory.py
+++ b/python/lsst/sims/featureScheduler/modelObservatory/model_observatory.py
@@ -249,8 +249,8 @@ class Model_observatory(object):
 
         self.conditions.telRA = self.observatory.current_coords[0]
         self.conditions.telDec = self.observatory.current_coords[1]
-        # self.conditions.telAlt = self.observatory.current_state.alt_rad
-        # self.conditions.telAz = self.observatory.current_state.az_rad
+        self.conditions.telAlt = self.observatory.last_alt_rad
+        self.conditions.telAz = self.observatory.last_az_rad
 
         self.conditions.rotTelPos = self.observatory.last_rot_tel_pos_rad
 
@@ -424,12 +424,11 @@ class Model_observatory(object):
         if np.isnan(observation['rotSkyPos']):
             observation = self._update_rotSkyPos(observation)
 
-        #start_ra = self.observatory.current_coords[0]
-        #start_dec = self.observatory.current_coords[1]
         start_alt = self.observatory.last_alt_rad
         start_az = self.observatory.last_az_rad
         slewtime, visittime = self.observatory.observe(observation, self.mjd)
 
+        # inf slewtime means the observation failed
         if ~np.all(np.isfinite(slewtime)):
             result = None
             new_night = False
@@ -438,7 +437,6 @@ class Model_observatory(object):
         # Check if the mjd after slewtime and visitime is fine:
         observation_worked, new_mjd = self.check_mjd(self.mjd + (slewtime + visittime)/24./3600.)
 
-        # inf slewtime means the observation failed
         if observation_worked:
             observation['visittime'] = visittime
             observation['slewtime'] = slewtime

--- a/python/lsst/sims/featureScheduler/modelObservatory/model_observatory.py
+++ b/python/lsst/sims/featureScheduler/modelObservatory/model_observatory.py
@@ -1,6 +1,6 @@
 import numpy as np
 from lsst.sims.utils import (_hpid2RaDec, _raDec2Hpid, Site, calcLmstLast,
-                             m5_flat_sed, _approx_RaDec2AltAz, _angularSeparation)
+                             m5_flat_sed, _approx_RaDec2AltAz, _angularSeparation, _approx_altaz2pa)
 import lsst.sims.skybrightness_pre as sb
 import healpy as hp
 from lsst.sims.downtimeModel import ScheduledDowntimeData, UnscheduledDowntimeData
@@ -8,7 +8,7 @@ import lsst.sims.downtimeModel as downtimeModel
 from lsst.sims.seeingModel import SeeingData, SeeingModel
 from lsst.sims.cloudModel import CloudData
 from lsst.sims.featureScheduler.features import Conditions
-from lsst.sims.featureScheduler.utils import set_default_nside, approx_altaz2pa, create_season_offset
+from lsst.sims.featureScheduler.utils import set_default_nside, create_season_offset
 from astropy.coordinates import EarthLocation
 from astropy.time import Time
 from lsst.sims.almanac import Almanac
@@ -409,7 +409,7 @@ class Model_observatory(object):
         """
         alt, az = _approx_RaDec2AltAz(observation['RA'], observation['dec'], self.site.latitude_rad,
                                       self.site.longitude_rad, self.mjd)
-        obs_pa = approx_altaz2pa(alt, az, self.site.latitude_rad)
+        obs_pa = _approx_altaz2pa(alt, az, self.site.latitude_rad)
         observation['rotSkyPos'] = (obs_pa + observation['rotTelPos']) % (2*np.pi)
         observation['rotTelPos'] = 0.
 

--- a/python/lsst/sims/featureScheduler/modelObservatory/model_observatory.py
+++ b/python/lsst/sims/featureScheduler/modelObservatory/model_observatory.py
@@ -429,14 +429,10 @@ class Model_observatory(object):
         # obsevation['rotSkyPos'] will be ignored.
         slewtime, visittime = self.observatory.observe(observation, self.mjd, rotTelPos=observation['rotTelPos'])
 
-        # inf slewtime means the observation failed
+        # inf slewtime means the observation failed (probably outsire alt limits)
         if ~np.all(np.isfinite(slewtime)):
-            result = None
-            new_night = False
-            import pdb ; pdb.set_trace()
-            raise ValueError("Slew failed")
+            return None, False
 
-        # Check if the mjd after slewtime and visitime is fine:
         observation_worked, new_mjd = self.check_mjd(self.mjd + (slewtime + visittime)/24./3600.)
 
         if observation_worked:

--- a/python/lsst/sims/featureScheduler/modelObservatory/model_observatory.py
+++ b/python/lsst/sims/featureScheduler/modelObservatory/model_observatory.py
@@ -3,269 +3,21 @@ from lsst.sims.utils import (_hpid2RaDec, _raDec2Hpid, Site, calcLmstLast,
                              m5_flat_sed, _approx_RaDec2AltAz, _angularSeparation)
 import lsst.sims.skybrightness_pre as sb
 import healpy as hp
-from datetime import datetime
 from lsst.sims.downtimeModel import ScheduledDowntimeData, UnscheduledDowntimeData
 import lsst.sims.downtimeModel as downtimeModel
 from lsst.sims.seeingModel import SeeingData, SeeingModel
 from lsst.sims.cloudModel import CloudData
 from lsst.sims.featureScheduler.features import Conditions
 from lsst.sims.featureScheduler.utils import set_default_nside, approx_altaz2pa, create_season_offset
-from lsst.ts.observatory.model import ObservatoryModel, Target
 from astropy.coordinates import EarthLocation
 from astropy.time import Time
 from lsst.sims.almanac import Almanac
 import warnings
 import matplotlib.pylab as plt
-from lsst.ts.observatory.model import ObservatoryState
 from importlib import import_module
+#from lsst.sims.featureScheduler.modelObservatory import Kinem_model
 
 __all__ = ['Model_observatory']
-
-
-class ExtendedObservatoryModel(ObservatoryModel):
-    """Add some functionality to ObservatoryModel
-    """
-
-    def expose(self, target):
-        # Break out the exposure command from observe method
-        visit_time = sum(target.exp_times) + \
-            target.num_exp * self.params.shuttertime + \
-            max(target.num_exp - 1, 0) * self.params.readouttime
-        self.update_state(self.current_state.time + visit_time)
-
-    def observe_times(self, target):
-        """observe a target, and return the slewtime and visit time for the action
-        Note, slew and expose will update the current_state
-        """
-        t1 = self.current_state.time + 0
-        # Note, this slew assumes there is a readout that needs to be done.
-        self.slew(target)
-        t2 = self.current_state.time + 0
-        self.expose(target)
-        t3 = self.current_state.time + 0
-        if not self.current_state.tracking:
-            ValueError('Telescope model stopped tracking, that seems bad.')
-        slewtime = t2 - t1
-        visitime = t3 - t2
-        return slewtime, visitime
-
-    #  Adding wrap_padding to make azimuth slews more intelligent
-    def get_closest_angle_distance(self, target_rad, current_abs_rad,
-                                   min_abs_rad=None, max_abs_rad=None,
-                                   wrap_padding=0.873):
-        """Calculate the closest angular distance including handling \
-           cable wrap if necessary.
-
-        Parameters
-        ----------
-        target_rad : float
-            The destination angle (radians).
-        current_abs_rad : float
-            The current angle (radians).
-        min_abs_rad : float, optional
-            The minimum constraint angle (radians).
-        max_abs_rad : float, optional
-            The maximum constraint angle (radians).
-        wrap_padding : float (0.873)
-            The amount of padding to use to make sure we don't track into limits (radians).
-
-
-        Returns
-        -------
-        tuple(float, float)
-            (accumulated angle in radians, distance angle in radians)
-        """
-        # if there are wrap limits, normalizes the target angle
-        TWOPI = 2 * np.pi
-        if min_abs_rad is not None:
-            norm_target_rad = divmod(target_rad - min_abs_rad, TWOPI)[1] + min_abs_rad
-            if max_abs_rad is not None:
-                # if the target angle is unreachable
-                # then sets an arbitrary value
-                if norm_target_rad > max_abs_rad:
-                    norm_target_rad = max(min_abs_rad, norm_target_rad - np.pi)
-        else:
-            norm_target_rad = target_rad
-
-        # computes the distance clockwise
-        distance_rad = divmod(norm_target_rad - current_abs_rad, TWOPI)[1]
-
-        # take the counter-clockwise distance if shorter
-        if distance_rad > np.pi:
-            distance_rad = distance_rad - TWOPI
-
-        # if there are wrap limits
-        if (min_abs_rad is not None) and (max_abs_rad is not None):
-            # compute accumulated angle
-            accum_abs_rad = current_abs_rad + distance_rad
-
-            # if limits reached chose the other direction
-            if accum_abs_rad > max_abs_rad - wrap_padding:
-                distance_rad = distance_rad - TWOPI
-            if accum_abs_rad < min_abs_rad + wrap_padding:
-                distance_rad = distance_rad + TWOPI
-
-        # compute final accumulated angle
-        final_abs_rad = current_abs_rad + distance_rad
-
-        return (final_abs_rad, distance_rad)
-
-    #  Put in wrap padding kwarg so it's not used on camera rotation.
-    def get_closest_state(self, targetposition, istracking=False):
-        """Find the closest observatory state for the given target position.
-
-        Parameters
-        ----------
-        targetposition : :class:`.ObservatoryPosition`
-            A target position instance.
-        istracking : bool, optional
-            Flag for saying if the observatory is tracking. Default is False.
-
-        Returns
-        -------
-        :class:`.ObservatoryState`
-            The state that is closest to the current observatory state.
-
-        Binary schema
-        -------------
-        The binary schema used to determine the state of a proposed target. A
-        value of 1 indicates that is it failing. A value of 0 indicates that the
-        state is passing.
-        ___  ___  ___  ___  ___  ___
-         |    |    |    |    |    |
-        rot  rot  az   az   alt  alt
-        max  min  max  min  max  min
-
-        For example, if a proposed target exceeds the rotators maximum value,
-        and is below the minimum azimuth we would have a binary value of;
-
-         0    1    0    1    0    0
-
-        If the target passed, then no limitations would occur;
-
-         0    0    0    0    0    0
-        """
-        TWOPI = 2 * np.pi
-
-        valid_state = True
-        fail_record = self.current_state.fail_record
-        self.current_state.fail_state = 0
-
-        if targetposition.alt_rad < self.params.telalt_minpos_rad:
-            telalt_rad = self.params.telalt_minpos_rad
-            domalt_rad = self.params.telalt_minpos_rad
-            valid_state = False
-
-            if "telalt_minpos_rad" in fail_record:
-                fail_record["telalt_minpos_rad"] += 1
-            else:
-                fail_record["telalt_minpos_rad"] = 1
-
-            self.current_state.fail_state = self.current_state.fail_state | \
-                                            self.current_state.fail_value_table["altEmin"]
-
-        elif targetposition.alt_rad > self.params.telalt_maxpos_rad:
-            telalt_rad = self.params.telalt_maxpos_rad
-            domalt_rad = self.params.telalt_maxpos_rad
-            valid_state = False
-            if "telalt_maxpos_rad" in fail_record:
-                fail_record["telalt_maxpos_rad"] += 1
-            else:
-                fail_record["telalt_maxpos_rad"] = 1
-
-            self.current_state.fail_state = self.current_state.fail_state | \
-                                            self.current_state.fail_value_table["altEmax"]
-
-        else:
-            telalt_rad = targetposition.alt_rad
-            domalt_rad = targetposition.alt_rad
-
-        if istracking:
-            (telaz_rad, delta) = self.get_closest_angle_distance(targetposition.az_rad,
-                                                                 self.current_state.telaz_rad)
-            if telaz_rad < self.params.telaz_minpos_rad:
-                telaz_rad = self.params.telaz_minpos_rad
-                valid_state = False
-                if "telaz_minpos_rad" in fail_record:
-                    fail_record["telaz_minpos_rad"] += 1
-                else:
-                    fail_record["telaz_minpos_rad"] = 1
-
-                self.current_state.fail_state = self.current_state.fail_state | \
-                                                self.current_state.fail_value_table["azEmin"]
-
-            elif telaz_rad > self.params.telaz_maxpos_rad:
-                telaz_rad = self.params.telaz_maxpos_rad
-                valid_state = False
-                if "telaz_maxpos_rad" in fail_record:
-                    fail_record["telaz_maxpos_rad"] += 1
-                else:
-                    fail_record["telaz_maxpos_rad"] = 1
-
-                self.current_state.fail_state = self.current_state.fail_state | \
-                                                self.current_state.fail_value_table["azEmax"]
-
-        else:
-            (telaz_rad, delta) = self.get_closest_angle_distance(targetposition.az_rad,
-                                                                 self.current_state.telaz_rad,
-                                                                 self.params.telaz_minpos_rad,
-                                                                 self.params.telaz_maxpos_rad)
-
-        (domaz_rad, delta) = self.get_closest_angle_distance(targetposition.az_rad,
-                                                             self.current_state.domaz_rad)
-
-        if istracking:
-            (telrot_rad, delta) = self.get_closest_angle_distance(targetposition.rot_rad,
-                                                                  self.current_state.telrot_rad,
-                                                                  wrap_padding=0.)
-            if telrot_rad < self.params.telrot_minpos_rad:
-                telrot_rad = self.params.telrot_minpos_rad
-                valid_state = False
-                if "telrot_minpos_rad" in fail_record:
-                    fail_record["telrot_minpos_rad"] += 1
-                else:
-                    fail_record["telrot_minpos_rad"] = 1
-
-                self.current_state.fail_state = self.current_state.fail_state | \
-                                                self.current_state.fail_value_table["rotEmin"]
-
-            elif telrot_rad > self.params.telrot_maxpos_rad:
-                telrot_rad = self.params.telrot_maxpos_rad
-                valid_state = False
-                if "telrot_maxpos_rad" in fail_record:
-                    fail_record["telrot_maxpos_rad"] += 1
-                else:
-                    fail_record["telrot_maxpos_rad"] = 1
-
-                self.current_state.fail_state = self.current_state.fail_state | \
-                                                self.current_state.fail_value_table["rotEmax"]
-        else:
-            # if the target rotator angle is unreachable
-            # then sets an arbitrary value (opposite)
-            norm_rot_rad = divmod(targetposition.rot_rad - self.params.telrot_minpos_rad, TWOPI)[1] \
-                + self.params.telrot_minpos_rad
-            if norm_rot_rad > self.params.telrot_maxpos_rad:
-                targetposition.rot_rad = norm_rot_rad - np.pi
-            (telrot_rad, delta) = self.get_closest_angle_distance(targetposition.rot_rad,
-                                                                  self.current_state.telrot_rad,
-                                                                  self.params.telrot_minpos_rad,
-                                                                  self.params.telrot_maxpos_rad,
-                                                                  wrap_padding=0.)
-        targetposition.ang_rad = divmod(targetposition.pa_rad - telrot_rad, TWOPI)[1]
-
-        targetstate = ObservatoryState()
-        targetstate.set_position(targetposition)
-        targetstate.telalt_rad = telalt_rad
-        targetstate.telaz_rad = telaz_rad
-        targetstate.telrot_rad = telrot_rad
-        targetstate.domalt_rad = domalt_rad
-        targetstate.domaz_rad = domaz_rad
-        if istracking:
-            targetstate.tracking = valid_state
-
-        self.current_state.fail_record = fail_record
-
-        return targetstate
 
 
 class Model_observatory(object):
@@ -359,10 +111,7 @@ class Model_observatory(object):
 
         self.sky_model = sb.SkyModelPre(speedLoad=quickTest)
 
-        self.observatory = ExtendedObservatoryModel()
-        self.observatory.configure_from_module()
-        # Make it so it respects my requested rotator angles
-        self.observatory.params.rotator_followsky = True
+        self.observatory = Kinem_model()
 
         self.filterlist = ['u', 'g', 'r', 'i', 'z', 'y']
         self.seeing_FWHMeff = {}
@@ -470,17 +219,15 @@ class Model_observatory(object):
                                                                   planet_mask=False,
                                                                   moon_mask=False, zenith_mask=False)
 
-        self.conditions.mounted_filters = self.observatory.current_state.mountedfilters
-        self.conditions.current_filter = self.observatory.current_state.filter[0]
+        self.conditions.mounted_filters = self.observatory.mounted_filters
+        self.conditions.current_filter = self.observatory.current_filter[0]
 
         # Compute the slewtimes
         slewtimes = np.empty(alts.size, dtype=float)
         slewtimes.fill(np.nan)
-        slewtimes[good] = self.observatory.get_approximate_slew_delay(alts[good], azs[good],
-                                                                      self.observatory.current_state.filter,
-                                                                      lax_dome=self.lax_dome)
-        # Mask out anything the slewtime says is out of bounds
-        slewtimes[np.where(slewtimes < 0)] = np.nan
+        slewtimes[good] = self.observatory.slew_times(0., 0., alt_rad=alts[good], az_rad=azs[good],
+                                                      filtername=self.observatory.current_filter,
+                                                      lax_dome=self.lax_dome, update=False)
         self.conditions.slewtime = slewtimes
 
         # Let's get the sun and moon
@@ -500,12 +247,12 @@ class Model_observatory(object):
 
         self.conditions.lmst, last = calcLmstLast(self.mjd, self.site.longitude_rad)
 
-        self.conditions.telRA = self.observatory.current_state.ra_rad
-        self.conditions.telDec = self.observatory.current_state.dec_rad
-        self.conditions.telAlt = self.observatory.current_state.alt_rad
-        self.conditions.telAz = self.observatory.current_state.az_rad
+        self.conditions.telRA = self.observatory.current_coords[0]
+        self.conditions.telDec = self.observatory.current_coords[1]
+        # self.conditions.telAlt = self.observatory.current_state.alt_rad
+        # self.conditions.telAz = self.observatory.current_state.az_rad
 
-        self.conditions.rotTelPos = self.observatory.current_state.rot_rad
+        self.conditions.rotTelPos = self.observatory.last_rot_tel_pos_rad
 
         # Add in the almanac information
         self.conditions.night = self.night
@@ -673,19 +420,12 @@ class Model_observatory(object):
 
         start_night = self.night.copy()
 
-        # Make sure the kinematic model is set to the correct mjd
-        t = Time(self.mjd, format='mjd')
-        self.observatory.update_state(t.unix)
-
         if np.isnan(observation['rotSkyPos']):
             observation = self._update_rotSkyPos(observation)
 
-        target = Target(band_filter=observation['filter'], ra_rad=observation['RA'],
-                        dec_rad=observation['dec'], ang_rad=observation['rotSkyPos'],
-                        num_exp=observation['nexp'], exp_times=[observation['exptime']])
-        start_ra = self.observatory.current_state.ra_rad
-        start_dec = self.observatory.current_state.dec_rad
-        slewtime, visittime = self.observatory.observe_times(target)
+        start_ra = self.observatory.current_coords[0]
+        start_dec = self.observatory.current_coords[1]
+        slewtime, visittime = self.observatory.observe(observation)
 
         # Check if the mjd after slewtime and visitime is fine:
         observation_worked, new_mjd = self.check_mjd(self.mjd + (slewtime + visittime)/24./3600.)
@@ -700,16 +440,16 @@ class Model_observatory(object):
             observation['visittime'] = visittime
             observation['slewtime'] = slewtime
             observation['slewdist'] = _angularSeparation(start_ra, start_dec,
-                                                         self.observatory.current_state.ra_rad,
-                                                         self.observatory.current_state.dec_rad)
+                                                         self.observatory.current_coords[0],
+                                                         self.observatory.current_coords[1])
             self.mjd = self.mjd + slewtime/24./3600.
             # Reach into the observatory model to pull out the relevant data it has calculated
             # Note, this might be after the observation has been completed.
-            observation['alt'] = self.observatory.current_state.alt_rad
-            observation['az'] = self.observatory.current_state.az_rad
-            observation['pa'] = self.observatory.current_state.pa_rad
-            observation['rotTelPos'] = self.observatory.current_state.rot_rad
-            observation['rotSkyPos'] = self.observatory.current_state.ang_rad
+            observation['alt'] = self.observatory.last_alt_rad
+            observation['az'] = self.observatory.last_az_rad
+            observation['pa'] = self.observatory.last_pa_rad
+            observation['rotTelPos'] = self.observatory.last_rot_tel_pos_rad
+            observation['rotSkyPos'] = self.observatory.rotSkyPos
 
             # Metadata on observation is after slew and settle, so at start of exposure.
             result = self.observation_add_data(observation)

--- a/python/lsst/sims/featureScheduler/schedulers/core_scheduler.py
+++ b/python/lsst/sims/featureScheduler/schedulers/core_scheduler.py
@@ -4,8 +4,7 @@ import numpy as np
 import healpy as hp
 from lsst.sims.utils import _hpid2RaDec
 from lsst.sims.featureScheduler.utils import hp_in_lsst_fov, set_default_nside, hp_in_comcam_fov, int_rounded
-from lsst.sims.utils import _approx_RaDec2AltAz
-from lsst.sims.featureScheduler.utils import approx_altaz2pa
+from lsst.sims.utils import _approx_RaDec2AltAz, _approx_altaz2pa
 
 
 import logging
@@ -179,7 +178,7 @@ class Core_scheduler(object):
             if self.rotator_limits is not None:
                 alt, az = _approx_RaDec2AltAz(observation['RA'], observation['dec'], self.conditions.site.latitude_rad,
                                               self.conditions.site.longitude_rad, mjd)
-                obs_pa = approx_altaz2pa(alt, az, self.conditions.site.latitude_rad)
+                obs_pa = _approx_altaz2pa(alt, az, self.conditions.site.latitude_rad)
                 rotTelPos_expected = (obs_pa - observation['rotSkyPos']) % (2.*np.pi)
                 if (int_rounded(rotTelPos_expected) > int_rounded(self.rotator_limits[0])) & (int_rounded(rotTelPos_expected) < int_rounded(self.rotator_limits[1])):
                     diff = np.abs(self.rotator_limits - rotTelPos_expected)

--- a/python/lsst/sims/featureScheduler/sim_runner.py
+++ b/python/lsst/sims/featureScheduler/sim_runner.py
@@ -74,10 +74,7 @@ def sim_runner(observatory, scheduler, filter_scheduler=None, mjd_start=None, su
             # find out what filters we want mounted
             conditions = observatory.return_conditions()
             filters_needed = filter_scheduler(conditions)
-            swap_out = np.setdiff1d(conditions.mounted_filters, filters_needed)
-            for filtername in swap_out:
-                # ugh, "swap_filter" means "unmount filter"
-                observatory.observatory.swap_filter(filtername)
+            observatory.observatory.mount_filters(filters_needed)
 
         mjd = observatory.mjd + 0
         if verbose:

--- a/python/lsst/sims/featureScheduler/surveys/base_survey.py
+++ b/python/lsst/sims/featureScheduler/surveys/base_survey.py
@@ -26,9 +26,12 @@ class BaseSurvey(object):
         ignore it because 'mysurvey2' is a substring of 'mysurvey23'.
     detailers : list of lsst.sims.featureScheduler.detailers objects
         The detailers to apply to the list of observations.
+    scheduled_obs : np.array
+        An array of MJD values for when observations should execute.
     """
     def __init__(self, basis_functions, extra_features=None,
-                 ignore_obs=None, survey_name='', nside=None, detailers=None):
+                 ignore_obs=None, survey_name='', nside=None, detailers=None,
+                 scheduled_obs=None):
         if nside is None:
             nside = set_default_nside()
         if ignore_obs is None:
@@ -60,6 +63,12 @@ class BaseSurvey(object):
             self.detailers = [Zero_rot_detailer(nside=nside)]
         else:
             self.detailers = detailers
+
+        # Scheduled observations
+        self.scheduled_obs = scheduled_obs
+
+    def get_scheduled_obs(self):
+        return self.scheduled_obs
 
     def add_observation(self, observation, **kwargs):
         # Check each posible ignore string

--- a/python/lsst/sims/featureScheduler/surveys/scripted_surveys.py
+++ b/python/lsst/sims/featureScheduler/surveys/scripted_surveys.py
@@ -80,8 +80,13 @@ class Scripted_survey(BaseSurvey):
 
     def _check_alts_HA(self, observation, conditions):
         """Given scheduled observations, check which ones can be done in current conditions.
+
+        Parameters
+        ----------
+        observation : np.array
+            An array of scheduled observations. Probably generated with lsst.sims.featureScheduler.utils.scheduled_observation
         """
-        # Just do a fast ra,dec to alt,az conversion. Can use LMST from a feature.
+        # Just do a fast ra,dec to alt,az conversion.
         alt, az = _approx_RaDec2AltAz(observation['RA'], observation['dec'],
                                       conditions.site.latitude_rad, None,
                                       conditions.mjd,
@@ -133,7 +138,8 @@ class Scripted_survey(BaseSurvey):
 
         self.obs_wanted.sort(order='mjd')
         self.mjd_start = self.obs_wanted['mjd'] - self.obs_wanted['mjd_tol']
-        # Here is the atribute that gets returned to broadcast scheduled observations
+        # Here is the atribute that core scheduler checks to broadcast scheduled observations
+        # in the conditions object.
         self.scheduled_obs = self.obs_wanted['mjd']
 
     def generate_observations_rough(self, conditions):

--- a/python/lsst/sims/featureScheduler/surveys/surveys.py
+++ b/python/lsst/sims/featureScheduler/surveys/surveys.py
@@ -7,6 +7,7 @@ from lsst.sims.featureScheduler.utils import (int_binned_stat, int_rounded,
                                               gnomonic_project_toxy, tsp_convex)
 import copy
 from lsst.sims.utils import _angularSeparation, _hpid2RaDec, _approx_RaDec2AltAz, hp_grow_argsort
+import warnings
 
 __all__ = ['Greedy_survey', 'Blob_survey']
 
@@ -105,6 +106,8 @@ class Blob_survey(Greedy_survey):
         from lingering past when they should be executed. (minutes)
     twilight_scale : bool (True)
         Scale the block size to fill up to twilight. Set to False if running in twilight
+    in_twilight : bool (False)
+        Scale the block size to stay within twilight time. 
     check_scheduled : bool (True)
         Check if there are scheduled observations and scale blob size to match
     min_area : float (None)
@@ -120,7 +123,7 @@ class Blob_survey(Greedy_survey):
                  smoothing_kernel=None, nside=None,
                  dither=True, seed=42, ignore_obs=None,
                  survey_note='blob', detailers=None, camera='LSST',
-                 twilight_scale=True, check_scheduled=True, min_area=None):
+                 twilight_scale=True, in_twilight=False, check_scheduled=True, min_area=None):
 
         if nside is None:
             nside = set_default_nside()
@@ -138,6 +141,11 @@ class Blob_survey(Greedy_survey):
         self.read_approx = read_approx
         self.hpids = np.arange(hp.nside2npix(self.nside))
         self.twilight_scale = twilight_scale
+        self.in_twilight = in_twilight
+
+        if self.twilight_scale & self.in_twilight:
+            warnings.warn('Both twilight_scale and in_twilight are set to True. That is probably wrong.')
+
         self.min_area = min_area
         self.check_scheduled = check_scheduled
         # If we are taking pairs in same filter, no need to add filter change time.
@@ -194,8 +202,10 @@ class Blob_survey(Greedy_survey):
 
     def _set_block_size(self, conditions):
         """
-        Update the block size if it's getting near the end of the night.
+        Update the block size if it's getting near a break point.
         """
+
+        # If we are trying to get things done before twilight
         if self.twilight_scale:
             available_time = conditions.sun_n18_rising - conditions.mjd
             available_time *= 24.*60.  # to minutes
@@ -203,6 +213,7 @@ class Blob_survey(Greedy_survey):
         else:
             n_ideal_blocks = 4
 
+        # If we are trying to get things done before a scheduled simulation
         if self.check_scheduled:
             if len(conditions.scheduled_observations) > 0:
                 available_time = np.min(conditions.scheduled_observations) - conditions.mjd
@@ -210,6 +221,18 @@ class Blob_survey(Greedy_survey):
                 n_blocks = available_time / self.ideal_pair_time
                 if n_blocks < n_ideal_blocks:
                     n_ideal_blocks = n_blocks
+
+        # If we are trying to complete before twilight ends or the night ends
+        if self.in_twilight:
+            at1 = conditions.sun_n12_rising - conditions.mjd
+            at2 = conditions.sun_n18_setting - conditions.mjd
+            times = np.array([at1, at2])
+            times = times[np.where(times > 0)]
+            available_time = np.min(times)
+            available_time *= 24.*60.  # to minutes
+            n_blocks = available_time / self.ideal_pair_time
+            if n_blocks < n_ideal_blocks:
+                n_ideal_blocks = n_blocks
 
         if n_ideal_blocks >= 3:
             self.nvisit_block = int(np.floor(self.ideal_pair_time*60. / (self.slew_approx + self.exptime +

--- a/python/lsst/sims/featureScheduler/surveys/surveys.py
+++ b/python/lsst/sims/featureScheduler/surveys/surveys.py
@@ -50,10 +50,7 @@ class Greedy_survey(BaseMarkovDF_survey):
         # Let's find the best N from the fields
         order = np.argsort(self.reward)[::-1]
         # Crop off any NaNs
-        try:
-            order = order[~np.isnan(self.reward[order])]
-        except:
-            import pdb ; pdb.set_trace()
+        order = order[~np.isnan(self.reward[order])]
 
         iter = 0
         while True:

--- a/python/lsst/sims/featureScheduler/surveys/surveys.py
+++ b/python/lsst/sims/featureScheduler/surveys/surveys.py
@@ -50,7 +50,10 @@ class Greedy_survey(BaseMarkovDF_survey):
         # Let's find the best N from the fields
         order = np.argsort(self.reward)[::-1]
         # Crop off any NaNs
-        order = order[~np.isnan(self.reward[order])]
+        try:
+            order = order[~np.isnan(self.reward[order])]
+        except:
+            import pdb ; pdb.set_trace()
 
         iter = 0
         while True:

--- a/python/lsst/sims/featureScheduler/utils/utils.py
+++ b/python/lsst/sims/featureScheduler/utils/utils.py
@@ -366,6 +366,25 @@ def empty_observation():
     return result
 
 
+def scheduled_observation():
+    """Make an array for pre-scheduling observations
+
+    mjd_tol : float
+        The tolerance on how early an observation can execute (days).
+
+    """
+
+    # Standard things from the usual observations
+    names = ['ID', 'RA', 'dec', 'mjd', 'flush_by_mjd', 'exptime', 'filter', 'rotSkyPos', 'nexp',
+             'note']
+    types = [int, float, float, float, float, float, 'U1', float, float, 'U40']
+    names += ['mjd_tol', 'dist_tol', 'alt_min', 'alt_max', 'HA_max', 'HA_min', 'observed']
+    types += [float, float, float, float, float, float, bool]
+    result = np.zeros(1, dtype=list(zip(names, types)))
+    return result
+
+
+
 def obs_to_fbsobs(obs):
     """
     converts an Observation from the Driver (which is a normal python class)

--- a/python/lsst/sims/featureScheduler/utils/utils.py
+++ b/python/lsst/sims/featureScheduler/utils/utils.py
@@ -90,28 +90,6 @@ def set_default_nside(nside=None):
     return set_default_nside.nside
 
 
-def approx_altaz2pa(alt_rad, az_rad, latitude_rad):
-    """
-    A fast calculation of parallactic angle
-    XXX--could move this to lsst.sims.utils.approxCoordTransforms.py
-    Parameters
-    ----------
-    alt_rad : float
-        Altitude (radians)
-    az_rad : float
-        Azimuth (radians)
-    latitude_rad : float
-        The latitude of the observatory (radians)
-    """
-
-    y = np.sin(-az_rad)*np.cos(latitude_rad)
-    x = np.cos(alt_rad)*np.sin(latitude_rad) - np.sin(alt_rad)*np.cos(latitude_rad)*np.cos(-az_rad)
-    pa = np.arctan2(y, x)
-    # Make it run from 0-360 deg instead of of -180 to 180
-    pa = pa % (2.*np.pi)
-    return pa
-
-
 def int_binned_stat(ids, values, statistic=np.mean):
     """
     Like scipy.binned_statistic, but for unique int ids

--- a/python/lsst/sims/featureScheduler/utils/utils.py
+++ b/python/lsst/sims/featureScheduler/utils/utils.py
@@ -6,12 +6,9 @@ import numpy as np
 import healpy as hp
 import pandas as pd
 import matplotlib.path as mplPath
-import logging
 from lsst.sims.utils import _hpid2RaDec, xyz_angular_radius, _buildTree, _xyz_from_ra_dec
 from lsst.sims.featureScheduler import version
 from lsst.sims.survey.fields import FieldsDatabase
-
-log = logging.getLogger(__name__)
 
 
 class int_rounded(object):

--- a/ups/sims_featureScheduler.table
+++ b/ups/sims_featureScheduler.table
@@ -7,7 +7,6 @@ setupRequired(sims_cloudModel)
 setupRequired(sims_downtimeModel)
 setupRequired(sims_survey_fields)
 setupRequired(sims_almanac)
-setupRequired(ts_observatory_model)
 
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)
 envPrepend(PATH, ${PRODUCT_DIR}/bin)


### PR DESCRIPTION
Update the scripted surveys, updated scheduler so info about scheduled observations gets passed in `conditions` object. Re-wrote telescope kinematic model to remove `ts_` dependencies. Results in slightly longer runtime, but we now have more accurate slewtime maps and the scheduler can pass either rotTelPos or rotSkyPos. Also fixes bugs where observations could be executed outside of telescope limits and the rotation angles + parallactic angle were not consistent.